### PR TITLE
FIX #56

### DIFF
--- a/cmd/entity.go
+++ b/cmd/entity.go
@@ -126,7 +126,7 @@ func (c *Entity) Edit() error {
 		return err
 	}
 	if !ok {
-		c.keyPath, err = cli.Prompt(fmt.Sprintf("path to the %s nkey", label), "", true, c.ValidateNKey())
+		c.keyPath, err = cli.Prompt(fmt.Sprintf("path to the %s nkey", label), c.keyPath, true, c.ValidateNKey())
 		if err != nil {
 			return err
 		}
@@ -192,6 +192,9 @@ func (c *Entity) ValidateNKey() cli.Validator {
 		nk, err := store.ResolveKey(v)
 		if err != nil {
 			return err
+		}
+		if nk == nil {
+			return fmt.Errorf("a key is required")
 		}
 		t, err := store.KeyType(nk)
 		if err != nil {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -45,8 +45,11 @@ func (p *GenerateNKeysParam) PrintKey(kind nkeys.PrefixByte, cmd *cobra.Command)
 	if err != nil {
 		panic(err)
 	}
+	seed, err := kp.Seed()
+	cmd.Println(string(seed))
+
 	pub, err := kp.PublicKey()
-	cmd.Println(string(pub))
+	cmd.Println(pub)
 }
 
 func (p *GenerateNKeysParam) Run(cmd *cobra.Command) error {


### PR DESCRIPTION
specifying an account public key as a flag, can result in a panic if the user dismisses the interactive prompt - if the key is provided, it's default should be shown.