### PR TITLE
fixes to export/imports

### DIFF
--- a/cmd/addexport.go
+++ b/cmd/addexport.go
@@ -130,7 +130,7 @@ func (p *AddExportParams) PreInteractive(ctx ActionCtx) error {
 	if p.export.Name == "" {
 		p.export.Name = p.subject
 	}
-	p.export.Name, err = cli.Prompt("export name", p.export.Name, true, cli.LengthValidator(1))
+	p.export.Name, err = cli.Prompt("name", p.export.Name, true, cli.LengthValidator(1))
 
 	p.export.TokenReq, err = cli.PromptBoolean(fmt.Sprintf("private %s", p.export.Type.String()), p.export.TokenReq)
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -283,7 +283,7 @@ func RenderDate(d int64) string {
 		return ""
 	}
 
-	return fmt.Sprintf("%s (%s)", UnixToDate(d), HumanizedDate(d))
+	return fmt.Sprintf("%s", UnixToDate(d))
 }
 
 func NKeyValidator(kind nkeys.PrefixByte) cli.Validator {

--- a/cmd/describer.go
+++ b/cmd/describer.go
@@ -137,13 +137,13 @@ func (e *ExportsDescriber) Describe() string {
 	table.UTF8Box()
 
 	table.AddTitle("Exports")
-	table.AddHeaders("Type", "Subject", "Public")
+	table.AddHeaders("Name", "Type", "Subject", "Public")
 	for _, v := range e.Exports {
 		public := "Yes"
 		if v.TokenReq {
 			public = "No"
 		}
-		table.AddRow(strings.Title(v.Type.String()), v.Subject, public)
+		table.AddRow(v.Name, strings.Title(v.Type.String()), v.Subject, public)
 	}
 	return table.Render()
 }
@@ -161,7 +161,7 @@ func NewImportsDescriber(imports jwt.Imports) *ImportsDescriber {
 func (i *ImportsDescriber) Describe() string {
 	table := tablewriter.CreateTable()
 	table.AddTitle("Imports")
-	table.AddHeaders("Type", "Subject", "To", "Expires", "From Account")
+	table.AddHeaders("Name", "Type", "Remote", "Local", "Expires", "From Account", "Public")
 
 	for _, v := range i.Imports {
 		NewImportDescriber(*v).Brief(table)
@@ -179,8 +179,15 @@ func NewImportDescriber(im jwt.Import) *ImportDescriber {
 }
 
 func (i *ImportDescriber) Brief(table *tablewriter.Table) {
+	local := string(i.To)
+	remote := string(i.Subject)
+
+	if i.Type == jwt.Service {
+		local, remote = remote, local
+	}
+
 	if i.Token == "" {
-		table.AddRow(strings.Title(i.Type.String()), string(i.Subject), string(i.To), "", ShortCodes(i.Account))
+		table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, "", ShortCodes(i.Account), "Yes")
 		return
 	}
 	expiration := ""
@@ -190,7 +197,7 @@ func (i *ImportDescriber) Brief(table *tablewriter.Table) {
 	} else {
 		expiration = RenderDate(ac.Expires)
 	}
-	table.AddRow(strings.Title(i.Type.String()), string(i.Subject), string(i.To), expiration, ShortCodes(i.Account))
+	table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, expiration, ShortCodes(i.Account), "No")
 }
 
 func (i *ImportDescriber) IsRemoteImport() bool {

--- a/cmd/generateactivation_test.go
+++ b/cmd/generateactivation_test.go
@@ -96,7 +96,7 @@ func Test_GenerateActivationNoPrivateExports(t *testing.T) {
 
 	_, _, err := ExecuteCmd(createGenerateActivationCmd())
 	require.Error(t, err)
-	require.Equal(t, "account \"A\" doesn't have exports that require token generation", err.Error())
+	require.Equal(t, "account \"A\" doesn't have stream exports that require token generation", err.Error())
 }
 
 func Test_GenerateActivationOutputsFile(t *testing.T) {
@@ -109,7 +109,7 @@ func Test_GenerateActivationOutputsFile(t *testing.T) {
 	_, pub, _ := CreateAccountKey(t)
 
 	outpath := filepath.Join(ts.Dir, "token.jwt")
-	_, _, err := ExecuteCmd(createGenerateActivationCmd(), "--target-account", pub, "--output-file", outpath)
+	_, _, err := ExecuteCmd(createGenerateActivationCmd(), "--service", "--target-account", pub, "--output-file", outpath)
 	require.NoError(t, err)
 	testExternalToken(t, outpath)
 }
@@ -146,7 +146,7 @@ func Test_InteractiveGenerate(t *testing.T) {
 	_, pub, _ := CreateAccountKey(t)
 
 	outpath := filepath.Join(ts.Dir, "token.jwt")
-	inputs := []interface{}{0, pub, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
+	inputs := []interface{}{true, 0, "foo", pub, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 
@@ -166,12 +166,9 @@ func Test_InteractiveExternalKeyGenerate(t *testing.T) {
 	outpath := filepath.Join(ts.Dir, "token.jwt")
 
 	_, pub, _ := CreateAccountKey(t)
-	keyfile := filepath.Join(ts.Dir, "key")
-	err := ioutil.WriteFile(keyfile, []byte(pub), 0700)
-	require.NoError(t, err)
 
-	inputs := []interface{}{0, keyfile, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
-	_, _, err = ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
+	inputs := []interface{}{true, 0, "foo", pub, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
+	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 
 	testExternalToken(t, outpath)
@@ -192,7 +189,7 @@ func Test_InteractiveMultipleAccountsGenerate(t *testing.T) {
 
 	_, pub, _ := CreateAccountKey(t)
 
-	inputs := []interface{}{0, 0, pub, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
+	inputs := []interface{}{0, true, 0, "foo", pub, "0", "0", ts.KeyStore.GetAccountKeyPath("A")}
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 

--- a/cmd/pubkeyparams.go
+++ b/cmd/pubkeyparams.go
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/nats-io/nkeys"
+	"github.com/nats-io/nsc/cli"
+	"github.com/nats-io/nsc/cmd/store"
+	"github.com/spf13/cobra"
+)
+
+type PubKeyParams struct {
+	flagName  string
+	kind      nkeys.PrefixByte
+	publicKey string
+}
+
+func (e *PubKeyParams) BindFlags(flagName string, shorthand string, kind nkeys.PrefixByte, cmd *cobra.Command) {
+	e.flagName = flagName
+	e.kind = kind
+	cmd.Flags().StringVarP(&e.publicKey, flagName, shorthand, "", flagName)
+}
+
+func (e *PubKeyParams) valid(s string) error {
+	if s == "" {
+		return fmt.Errorf("%s cannot be empty", e.flagName)
+	}
+
+	if !store.IsPublicKey(e.kind, s) {
+		return fmt.Errorf("%s is not a valid %q public key", e.publicKey, e.kind.String())
+	}
+
+	return nil
+}
+
+func (e *PubKeyParams) Valid() error {
+	return e.valid(e.publicKey)
+}
+
+func (e *PubKeyParams) Edit() error {
+	sv, err := cli.Prompt(fmt.Sprintf("%s public key", e.flagName), e.publicKey, true, e.valid)
+	if err != nil {
+		return err
+	}
+	e.publicKey = sv
+	return nil
+}


### PR DESCRIPTION
- FIX #59 - jwt Subject/To are flipped for services, describe account references them as local/remote
- FIX #63 - fixed panic on interactive. When public keys are requested, for generating an activation or adding an import, the public key is requested - not a file 
- FIX #64 - when importing an activation token, it is now possible to supply the bare activation jwt. 
- FIX #65 - When generating an activation token the subject must match or be contained by the export's subject. In the case of services wildcards are not allowed.