### PR TITLE
FIX #71

### DIFF
--- a/cmd/addimport.go
+++ b/cmd/addimport.go
@@ -235,6 +235,9 @@ func (p *AddImportParams) initFromActivation(ctx ActionCtx) error {
 	}
 
 	p.srcAccount.publicKey = ac.Issuer
+	if ac.IssuerAccount != "" {
+		p.srcAccount.publicKey = ac.IssuerAccount
+	}
 
 	if ac.Subject != "public" && p.claim.Subject != ac.Subject {
 		return fmt.Errorf("activation is not intended for this account - it is for %q", ac.Subject)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -105,6 +105,8 @@ func ExecuteCmd(root *cobra.Command, args ...string) (stdout string, stderr stri
 	os.Stdout = old
 	_, _ = io.Copy(&stdoutBuf, r)
 
+	ResetSharedFlags()
+
 	return stdoutBuf.String(), stderrBuf.String(), err
 }
 
@@ -125,6 +127,8 @@ func ExecuteInteractiveCmd(root *cobra.Command, inputs []interface{}, args ...st
 	_ = w.Close()
 	os.Stdout = old
 	_, _ = io.Copy(&stdoutBuf, r)
+
+	ResetSharedFlags()
 
 	return stdoutBuf.String(), stderrBuf.String(), err
 }

--- a/cmd/generateactivation.go
+++ b/cmd/generateactivation.go
@@ -274,7 +274,7 @@ func (p *GenerateActivationParams) Run(ctx ActionCtx) error {
 		return err
 	}
 	if p.claims.Subject != spub {
-		p.activation.IssuerAccount = p.claims.Issuer
+		p.activation.IssuerAccount = p.claims.Subject
 	}
 
 	p.Token, err = p.activation.Encode(p.signerKP)

--- a/cmd/generateactivation_test.go
+++ b/cmd/generateactivation_test.go
@@ -229,5 +229,5 @@ func Test_GenerateActivationUsingSigningKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, actc.Issuer, pk)
 	require.True(t, ac.DidSign(actc))
-	require.Equal(t, actc.IssuerAccount, ac.Issuer)
+	require.Equal(t, actc.IssuerAccount, ac.Subject)
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -45,6 +45,10 @@ type TestStore struct {
 // Some globals must be reset
 func ResetForTests() {
 	config = ToolConfig{}
+	ResetSharedFlags()
+}
+
+func ResetSharedFlags() {
 	KeyPathFlag = ""
 }
 


### PR DESCRIPTION
importing an activation token must handle the account issuer field, and set account to the account issuer if set.