### PR TITLE
implemented inline jwts for operator, this simplifies generate config.

### DIFF
--- a/cmd/memresolverconfigbuilder.go
+++ b/cmd/memresolverconfigbuilder.go
@@ -17,20 +17,33 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"sort"
 
 	"github.com/nats-io/jwt"
+	"github.com/nats-io/nsc/cmd/store"
 )
 
 type MemResolverConfigBuilder struct {
-	claims map[string]string
+	operator  string
+	claims    map[string]string
+	pubToName map[string]string
+	dir       string
 }
 
 func NewMemResolverConfigBuilder() *MemResolverConfigBuilder {
 	cb := MemResolverConfigBuilder{}
 	cb.claims = make(map[string]string)
+	cb.pubToName = make(map[string]string)
 	return &cb
+}
+
+func (cb *MemResolverConfigBuilder) SetOutputDir(fp string) error {
+	cb.dir = fp
+	return nil
 }
 
 func (cb *MemResolverConfigBuilder) Add(rawClaim []byte) error {
@@ -40,36 +53,110 @@ func (cb *MemResolverConfigBuilder) Add(rawClaim []byte) error {
 		return err
 	}
 	switch gc.Type {
+	case jwt.OperatorClaim:
+		oc, err := jwt.DecodeOperatorClaims(token)
+		if err != nil {
+			return err
+		}
+		cb.operator = token
+		cb.pubToName[oc.Subject] = oc.Name
+		cb.pubToName["__OPERATOR__"] = oc.Subject
 	case jwt.AccountClaim:
 		ac, err := jwt.DecodeAccountClaims(token)
 		if err != nil {
 			return err
 		}
 		cb.claims[ac.Subject] = token
+		cb.pubToName[ac.Subject] = ac.Name
 	}
 	return nil
 }
 
-func (cb *MemResolverConfigBuilder) Generate(ofp string) ([]byte, error) {
+func (cb *MemResolverConfigBuilder) GenerateConfig() ([]byte, error) {
 	var buf bytes.Buffer
+
+	opk := cb.pubToName["__OPERATOR__"]
+	if opk == "" {
+		return nil, errors.New("operator is not set")
+	}
+	buf.WriteString(fmt.Sprintf("// Operator %q\n", cb.pubToName[opk]))
+	buf.WriteString(fmt.Sprintf("operator: %s\n", cb.operator))
 
 	var keys []string
 	for k := range cb.claims {
 		keys = append(keys, k)
 	}
 	sort.Strings(keys)
-
-	if ofp != "" && ofp != "--" {
-		buf.WriteString(fmt.Sprintf("operator: %q\n", ofp))
-	} else if ofp == "--" {
-		buf.WriteString("# operator: <specify_path_to_operator_jwt>\n")
-	}
 	buf.WriteString("resolver: MEMORY\n")
 	buf.WriteString("resolver_preload: {\n")
 	for _, k := range keys {
 		v := cb.claims[k]
+		buf.WriteString(fmt.Sprintf("  // Account %q\n", cb.pubToName[k]))
 		buf.WriteString(fmt.Sprintf("  %s: %s\n", k, v))
 	}
 	buf.WriteString("}\n")
 	return buf.Bytes(), nil
+}
+
+func (cb *MemResolverConfigBuilder) writeFile(dir string, name string, token string) (string, error) {
+	fp := filepath.Join(dir, store.JwtName(name))
+	err := ioutil.WriteFile(fp, []byte(token), 0666)
+	return fp, err
+}
+
+func (cb *MemResolverConfigBuilder) GenerateDir() ([]byte, error) {
+	var buf bytes.Buffer
+
+	if err := MaybeMakeDir(cb.dir); err != nil {
+		return nil, err
+	}
+
+	opk := cb.pubToName["__OPERATOR__"]
+	if opk == "" {
+		return nil, errors.New("operator is not set")
+	}
+
+	fn, err := cb.writeFile(cb.dir, cb.pubToName[opk], cb.operator)
+	if err != nil {
+		return nil, err
+	}
+	buf.WriteString(fmt.Sprintf("// Operator %q\n", cb.pubToName[opk]))
+	buf.WriteString(fmt.Sprintf("operator: %q\n", filepath.Join(".", filepath.Base(fn))))
+
+	var keys []string
+	for k := range cb.claims {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	buf.WriteString("resolver: MEMORY\n")
+	buf.WriteString("resolver_preload: {\n")
+	for _, k := range keys {
+		v := cb.claims[k]
+		n := cb.pubToName[k]
+		buf.WriteString(fmt.Sprintf("  // Account %q\n", n))
+		fn, err := cb.writeFile(cb.dir, n, v)
+		if err != nil {
+			return nil, err
+		}
+		rel, err := filepath.Rel(cb.dir, fn)
+		if err != nil {
+			return nil, err
+		}
+		buf.WriteString(fmt.Sprintf("  %s: %q\n", k, rel))
+	}
+	buf.WriteString("}\n")
+
+	err = ioutil.WriteFile(filepath.Join(cb.dir, "resolver.conf"), buf.Bytes(), 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (cb *MemResolverConfigBuilder) Generate() ([]byte, error) {
+	if cb.dir != "" {
+		return cb.GenerateDir()
+	}
+	return cb.GenerateConfig()
 }

--- a/cmd/nkeyconfigbuilder.go
+++ b/cmd/nkeyconfigbuilder.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -39,6 +40,10 @@ func NewNKeyConfigBuilder() *NKeyConfigBuilder {
 	cb.userClaims = make(map[string][]*jwt.UserClaims)
 	cb.srcToPrivateImports = make(map[string][]jwt.Import)
 	return &cb
+}
+
+func (cb *NKeyConfigBuilder) SetOutputDir(fp string) error {
+	return errors.New("nkey configurations don't support directory output")
 }
 
 func (cb *NKeyConfigBuilder) Add(rawClaim []byte) error {
@@ -105,7 +110,7 @@ func (cb *NKeyConfigBuilder) addUserClaim(uc *jwt.UserClaims) {
 	cb.userClaims[apk] = users
 }
 
-func (cb *NKeyConfigBuilder) Generate(ofp string) ([]byte, error) {
+func (cb *NKeyConfigBuilder) Generate() ([]byte, error) {
 	if err := cb.parse(); err != nil {
 		return nil, err
 	}

--- a/cmd/nkeyconfigbuilder_test.go
+++ b/cmd/nkeyconfigbuilder_test.go
@@ -60,7 +60,7 @@ func Test_NkeyResolverBasicProperties(t *testing.T) {
 	err = builder.Add(ub)
 	require.NoError(t, err)
 
-	d, err := builder.Generate("")
+	d, err := builder.Generate()
 	require.NoError(t, err)
 
 	conf := string(d)
@@ -86,7 +86,7 @@ func Test_NkeyResolverExportsStreamsServices(t *testing.T) {
 	err = builder.Add(a)
 	require.NoError(t, err)
 
-	d, err := builder.Generate("")
+	d, err := builder.Generate()
 	require.NoError(t, err)
 
 	conf := string(d)
@@ -112,7 +112,7 @@ func Test_NkeyResolverExportsPrivateStreamsServices(t *testing.T) {
 	err = builder.Add(a)
 	require.NoError(t, err)
 
-	d, err := builder.Generate("")
+	d, err := builder.Generate()
 	require.NoError(t, err)
 
 	conf := string(d)
@@ -148,7 +148,7 @@ func Test_NkeyResolverMapsImporter(t *testing.T) {
 	err = builder.Add(b)
 	require.NoError(t, err)
 
-	d, err := builder.Generate("")
+	d, err := builder.Generate()
 	require.NoError(t, err)
 
 	conf := string(d)
@@ -187,11 +187,11 @@ func Test_NkeyResolverAddsSigningKeyUser(t *testing.T) {
 
 	ua, err := ts.Store.Read(store.Accounts, "A", store.Users, store.JwtName("ua"))
 	require.NoError(t, err)
-	builder.Add(ua)
+	require.NoError(t, builder.Add(ua))
 	uc, err := ts.Store.ReadUserClaim("A", "ua")
 	require.NoError(t, err)
 
-	d, err := builder.Generate("")
+	d, err := builder.Generate()
 	require.NoError(t, err)
 
 	conf := string(d)

--- a/cmd/replytool.go
+++ b/cmd/replytool.go
@@ -136,9 +136,9 @@ func (p *RepParams) Run(ctx ActionCtx) error {
 		if err := sub.AutoUnsubscribe(p.maxMessages); err != nil {
 			return err
 		}
-		ctx.CurrentCmd().Printf("Listening on [%s] for %d messages", subj, p.maxMessages)
+		ctx.CurrentCmd().Printf("Listening on [%s] for %d messages\n", subj, p.maxMessages)
 	} else {
-		ctx.CurrentCmd().Printf("Listening on [%s]", subj)
+		ctx.CurrentCmd().Printf("Listening on [%s]\n", subj)
 	}
 
 	if err := nc.Flush(); err != nil {

--- a/cmd/reqtool.go
+++ b/cmd/reqtool.go
@@ -120,6 +120,6 @@ func (p *ReqParams) Run(ctx ActionCtx) error {
 		return err
 	}
 
-	ctx.CurrentCmd().Printf("Received reply: [%v] : '%s'", msg.Subject, string(msg.Data))
+	ctx.CurrentCmd().Printf("Received reply: [%v] : '%s'\n", msg.Subject, string(msg.Data))
 	return nil
 }

--- a/cmd/subtool.go
+++ b/cmd/subtool.go
@@ -132,9 +132,9 @@ func (p *SubParams) Run(ctx ActionCtx) error {
 		if err := sub.AutoUnsubscribe(p.maxMessages); err != nil {
 			return err
 		}
-		ctx.CurrentCmd().Printf("Listening on [%s] for %d messages", subj, p.maxMessages)
+		ctx.CurrentCmd().Printf("Listening on [%s] for %d messages\n", subj, p.maxMessages)
 	} else {
-		ctx.CurrentCmd().Printf("Listening on [%s]", subj)
+		ctx.CurrentCmd().Printf("Listening on [%s]\n", subj)
 	}
 
 	if err := nc.Flush(); err != nil {
@@ -158,7 +158,7 @@ func (p *SubParams) Run(ctx ActionCtx) error {
 		}
 
 		i++
-		ctx.CurrentCmd().Printf("[#%d] Received on [%s]: '%s'", i, msg.Subject, string(msg.Data))
+		ctx.CurrentCmd().Printf("[#%d] Received on [%s]: '%s'\n", i, msg.Subject, string(msg.Data))
 	}
 
 	return nil

--- a/cmd/tools_test.go
+++ b/cmd/tools_test.go
@@ -35,12 +35,9 @@ func TestPub(t *testing.T) {
 	ts.AddUser(t, "A", "U")
 
 	// create the basic configuration
-	opjwt := filepath.Join(ts.Dir, "operator.jwt")
 	serverconf := filepath.Join(ts.Dir, "server.conf")
-
 	_, _, err := ExecuteCmd(createServerConfigCmd(), "--mem-resolver",
-		"--config-file", serverconf,
-		"--operator-jwt", opjwt)
+		"--config-file", serverconf)
 	require.NoError(t, err)
 
 	// start a server with the config at a random port
@@ -84,12 +81,9 @@ func TestSub(t *testing.T) {
 	ts.AddUser(t, "A", "U")
 
 	// create the basic configuration
-	op := filepath.Join(ts.Dir, "operator.jwt")
 	conf := filepath.Join(ts.Dir, "server.conf")
-
 	_, _, err := ExecuteCmd(createServerConfigCmd(), "--mem-resolver",
-		"--config-file", conf,
-		"--operator-jwt", op)
+		"--config-file", conf)
 	require.NoError(t, err)
 
 	// start a server with the config at a random port
@@ -147,12 +141,10 @@ func TestReq(t *testing.T) {
 	ts.AddUser(t, "A", "U")
 
 	// create the basic configuration
-	op := filepath.Join(ts.Dir, "operator.jwt")
 	conf := filepath.Join(ts.Dir, "server.conf")
 
 	_, _, err := ExecuteCmd(createServerConfigCmd(), "--mem-resolver",
-		"--config-file", conf,
-		"--operator-jwt", op)
+		"--config-file", conf)
 	require.NoError(t, err)
 
 	// start a server with the config at a random port
@@ -191,12 +183,9 @@ func TestReply(t *testing.T) {
 	ts.AddUser(t, "A", "U")
 
 	// create the basic configuration
-	op := filepath.Join(ts.Dir, "operator.jwt")
 	conf := filepath.Join(ts.Dir, "server.conf")
-
 	_, _, err := ExecuteCmd(createServerConfigCmd(), "--mem-resolver",
-		"--config-file", conf,
-		"--operator-jwt", op)
+		"--config-file", conf)
 	require.NoError(t, err)
 
 	// start a server with the config at a random port

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
 	github.com/nats-io/jwt v0.2.8
-	github.com/nats-io/nats-server/v2 v2.0.0
+	github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329
 	github.com/nats-io/nats.go v1.8.2-0.20190607221125-9f4d16fe7c2d
 	github.com/nats-io/nkeys v0.0.2
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/nats-io/jwt v0.2.8/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrW
 github.com/nats-io/nats-server v1.4.1 h1:Ul1oSOGNV/L8kjr4v6l2f9Yet6WY+LevH1/7cRZ/qyA=
 github.com/nats-io/nats-server/v2 v2.0.0 h1:rbFV7gfUPErVdKImVMOlW8Qb1V22nlcpqup5cb9rYa8=
 github.com/nats-io/nats-server/v2 v2.0.0/go.mod h1:RyVdsHHvY4B6c9pWG+uRLpZ0h0XsqiuKp2XCTurP5LI=
+github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329 h1:RjMdWlS/avIVeXLjWxrHmxoiNPcvLXVWqpO7Bp6hyTk=
+github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329/go.mod h1:RyVdsHHvY4B6c9pWG+uRLpZ0h0XsqiuKp2XCTurP5LI=
 github.com/nats-io/nats.go v1.8.0/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ=
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=

--- a/vendor/github.com/nats-io/nats-server/v2/server/const.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/const.go
@@ -40,7 +40,7 @@ var (
 
 const (
 	// VERSION is the current version for the server.
-	VERSION = "2.0.0"
+	VERSION = "2.0.1"
 
 	// PROTO is the currently supported protocol.
 	// 0 was the original
@@ -114,6 +114,9 @@ const (
 
 	// DEFAULT_LEAF_NODE_RECONNECT LeafNode reconnect interval.
 	DEFAULT_LEAF_NODE_RECONNECT = time.Second
+
+	// DEFAULT_LEAF_TLS_TIMEOUT TLS timeout for LeafNodes
+	DEFAULT_LEAF_TLS_TIMEOUT = 2 * time.Second
 
 	// PROTO_SNIPPET_SIZE is the default size of proto to print on parse errors.
 	PROTO_SNIPPET_SIZE = 32

--- a/vendor/github.com/nats-io/nats-server/v2/server/jwt.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/jwt.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"regexp"
+	"strings"
 
 	"github.com/nats-io/jwt"
 	"github.com/nats-io/nkeys"
@@ -24,11 +25,19 @@ import (
 
 var nscDecoratedRe = regexp.MustCompile(`\s*(?:(?:[-]{3,}[^\n]*[-]{3,}\n)(.+)(?:\n\s*[-]{3,}[^\n]*[-]{3,}[\n]*))`)
 
+// All JWTs once encoded start with this
+const jwtPrefix = "eyJ"
+
 // readOperatorJWT
 func readOperatorJWT(jwtfile string) (*jwt.OperatorClaims, error) {
 	contents, err := ioutil.ReadFile(jwtfile)
 	if err != nil {
-		return nil, err
+		// Check to see if the JWT has been inlined.
+		if !strings.HasPrefix(jwtfile, jwtPrefix) {
+			return nil, err
+		}
+		// We may have an inline jwt here.
+		contents = []byte(jwtfile)
 	}
 	defer wipeSlice(contents)
 

--- a/vendor/github.com/nats-io/nats-server/v2/server/leafnode.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/leafnode.go
@@ -1221,6 +1221,11 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 		return
 	}
 
+	// Check to see if we need to map/route to another account.
+	if acc.imports.services != nil {
+		c.checkForImportServices(acc, msg)
+	}
+
 	// Match the subscriptions. We will use our own L1 map if
 	// it's still valid, avoiding contention on the shared sublist.
 	var r *SublistResult
@@ -1249,11 +1254,6 @@ func (c *client) processInboundLeafMsg(msg []byte) {
 				}
 			}
 		}
-	}
-
-	// Check to see if we need to map/route to another account.
-	if acc.imports.services != nil {
-		c.checkForImportServices(acc, msg)
 	}
 
 	// Collect queue names if needed.

--- a/vendor/github.com/nats-io/nats-server/v2/server/monitor.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/monitor.go
@@ -980,7 +980,7 @@ func (s *Server) HandleRoot(w http.ResponseWriter, r *http.Request) {
 	<a href=/routez>routez</a><br/>
 	<a href=/subsz>subsz</a><br/>
     <br/>
-    <a href=http://nats.io/documentation/server/monitoring/>help</a>
+    <a href=https://nats-io.github.io/docs/nats_server/monitoring.html>help</a>
   </body>
 </html>`)
 }

--- a/vendor/github.com/nats-io/nats-server/v2/server/opts.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/opts.go
@@ -602,9 +602,7 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 				err := &configErr{tk, fmt.Sprintf("error parsing operators: unsupported type %T", v)}
 				errors = append(errors, err)
 			}
-			// Assume for now these are file names.
-			// TODO(dlc) - If we try to read the file and it fails we could treat the string
-			// as the JWT itself.
+			// Assume for now these are file names, but they can also be the JWT itself inline.
 			o.TrustedOperators = make([]*jwt.OperatorClaims, 0, len(opFiles))
 			for _, fname := range opFiles {
 				opc, err := readOperatorJWT(fname)
@@ -651,19 +649,26 @@ func (o *Options) ProcessConfigFile(configFile string) error {
 		case "resolver_preload":
 			mp, ok := v.(map[string]interface{})
 			if !ok {
-				err := &configErr{tk, fmt.Sprintf("preload should be a map of key:jwt")}
+				err := &configErr{tk, fmt.Sprintf("preload should be a map of account_public_key:account_jwt")}
 				errors = append(errors, err)
 				continue
 			}
 			o.resolverPreloads = make(map[string]string)
 			for key, val := range mp {
 				tk, val = unwrapValue(val)
-				if jwt, ok := val.(string); !ok {
-					err := &configErr{tk, fmt.Sprintf("preload map value should be a string jwt")}
+				if jwtstr, ok := val.(string); !ok {
+					err := &configErr{tk, fmt.Sprintf("preload map value should be a string JWT")}
 					errors = append(errors, err)
 					continue
 				} else {
-					o.resolverPreloads[key] = jwt
+					// Make sure this is a valid account JWT, that is a config error.
+					// We will warn of expirations, etc later.
+					if _, err := jwt.DecodeAccountClaims(jwtstr); err != nil {
+						err := &configErr{tk, fmt.Sprintf("invalid account JWT")}
+						errors = append(errors, err)
+						continue
+					}
+					o.resolverPreloads[key] = jwtstr
 				}
 			}
 		case "system_account", "system":
@@ -1096,7 +1101,11 @@ func parseRemoteLeafNodes(v interface{}, errors *[]error, warnings *[]error) ([]
 				// Set RootCAs since this tls.Config is used when soliciting
 				// a connection (therefore behaves as a client).
 				remote.TLSConfig.RootCAs = remote.TLSConfig.ClientCAs
-				remote.TLSTimeout = tc.Timeout
+				if tc.Timeout > 0 {
+					remote.TLSTimeout = tc.Timeout
+				} else {
+					remote.TLSTimeout = float64(DEFAULT_LEAF_TLS_TIMEOUT)
+				}
 			default:
 				if !tk.IsUsedVariable() {
 					err := &unknownConfigFieldErr{
@@ -2144,27 +2153,33 @@ func parseTLS(v interface{}) (*TLSConfigOpts, error) {
 
 // GenTLSConfig loads TLS related configuration parameters.
 func GenTLSConfig(tc *TLSConfigOpts) (*tls.Config, error) {
-
-	// Now load in cert and private key
-	cert, err := tls.LoadX509KeyPair(tc.CertFile, tc.KeyFile)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
-	}
-	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
-	if err != nil {
-		return nil, fmt.Errorf("error parsing certificate: %v", err)
-	}
-
-	// Create the tls.Config from our options.
-	// We will determine the cipher suites that we prefer.
+	// Create the tls.Config from our options before including the certs.
+	// It will determine the cipher suites that we prefer.
 	// FIXME(dlc) change if ARM based.
 	config := tls.Config{
 		MinVersion:               tls.VersionTLS12,
 		CipherSuites:             tc.Ciphers,
 		PreferServerCipherSuites: true,
 		CurvePreferences:         tc.CurvePreferences,
-		Certificates:             []tls.Certificate{cert},
 		InsecureSkipVerify:       tc.Insecure,
+	}
+
+	switch {
+	case tc.CertFile != "" && tc.KeyFile == "":
+		return nil, fmt.Errorf("missing 'key_file' in TLS configuration")
+	case tc.CertFile == "" && tc.KeyFile != "":
+		return nil, fmt.Errorf("missing 'cert_file' in TLS configuration")
+	case tc.CertFile != "" && tc.KeyFile != "":
+		// Now load in cert and private key
+		cert, err := tls.LoadX509KeyPair(tc.CertFile, tc.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing X509 certificate/key pair: %v", err)
+		}
+		cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			return nil, fmt.Errorf("error parsing certificate: %v", err)
+		}
+		config.Certificates = []tls.Certificate{cert}
 	}
 
 	// Require client certificates as needed

--- a/vendor/github.com/nats-io/nats-server/v2/server/reload.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/reload.go
@@ -882,6 +882,8 @@ func (s *Server) reloadAuthorization() {
 	} else if s.opts.AccountResolver != nil {
 		s.configureResolver()
 		if _, ok := s.accResolver.(*MemAccResolver); ok {
+			// Check preloads so we can issue warnings etc if needed.
+			s.checkResolvePreloads()
 			// With a memory resolver we want to do something similar to configured accounts.
 			// We will walk the accounts and delete them if they are no longer present via fetch.
 			// If they are present we will force a claim update to process changes.

--- a/vendor/github.com/nats-io/nats-server/v2/server/route.go
+++ b/vendor/github.com/nats-io/nats-server/v2/server/route.go
@@ -305,8 +305,8 @@ func (c *client) processInboundRoutedMsg(msg []byte) {
 	c.processMsgResults(acc, r, msg, c.pa.subject, c.pa.reply, pmrNoFlag)
 }
 
-// Helper function for routes and gateways to create qfilters need for
-// converted subs from imports, etc.
+// Helper function for routes and gateways and leafnodes to create qfilters
+// needed for converted subs from imports, etc.
 func (c *client) makeQFilter(qsubs [][]*subscription) {
 	qs := make([][]byte, 0, len(qsubs))
 	for _, qsub := range qsubs {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/mitchellh/go-wordwrap
 github.com/mitchellh/mapstructure
 # github.com/nats-io/jwt v0.2.8
 github.com/nats-io/jwt
-# github.com/nats-io/nats-server/v2 v2.0.0
+# github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329
 github.com/nats-io/nats-server/v2/server
 github.com/nats-io/nats-server/v2/conf
 github.com/nats-io/nats-server/v2/logger


### PR DESCRIPTION
Also implemented a hidden mode where the config references jwt files - requires server support.

usage on nsc is always available from nsc --help or by drilling:
```bash
nsc add operator -n O
nsc edit operator --service-url nats://localhost:4222
nsc add account -n A
nsc add user -n aa
nsc add account -n B
nsc add user -n bb

nsc generate config --mem-resolver --config-file /tmp/server.conf
```
On another terminal:
```bash
nats-server -c /tmp/server.conf
```

On another terminal:
```bash
nsc sub foo
```

On yet another:
```bash
nsc pub foo
```




