### PR TITLE
added ability to specify system account when generating mem-resolver configuration.

### DIFF
--- a/cmd/memresolverconfigbuilder_test.go
+++ b/cmd/memresolverconfigbuilder_test.go
@@ -185,3 +185,18 @@ func Test_MemResolverServerParse(t *testing.T) {
 	var opts server.Options
 	require.NoError(t, opts.ProcessConfigFile(serverconf))
 }
+
+func Test_MemResolverContainsSysAccount(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	ts.AddAccount(t, "A")
+	ts.AddAccount(t, "B")
+
+	stdout, _, err := ExecuteCmd(createServerConfigCmd(), "--mem-resolver",
+		"--sys-account", "B")
+	require.NoError(t, err)
+
+	ac, err := ts.Store.ReadAccountClaim("B")
+	require.NoError(t, err)
+	require.Contains(t, stdout, fmt.Sprintf("system_account: %s", ac.Subject))
+}

--- a/cmd/nkeyconfigbuilder.go
+++ b/cmd/nkeyconfigbuilder.go
@@ -30,6 +30,7 @@ type NKeyConfigBuilder struct {
 	accountClaims       map[string]*jwt.AccountClaims
 	userClaims          map[string][]*jwt.UserClaims
 	srcToPrivateImports map[string][]jwt.Import
+	sysAccount          string
 }
 
 func NewNKeyConfigBuilder() *NKeyConfigBuilder {
@@ -44,6 +45,10 @@ func NewNKeyConfigBuilder() *NKeyConfigBuilder {
 
 func (cb *NKeyConfigBuilder) SetOutputDir(fp string) error {
 	return errors.New("nkey configurations don't support directory output")
+}
+
+func (cb *NKeyConfigBuilder) SetSystemAccount(id string) error {
+	return errors.New("nkey configurations don't support system account")
 }
 
 func (cb *NKeyConfigBuilder) Add(rawClaim []byte) error {


### PR DESCRIPTION
```
nsc add operator -n O
nsc add account -n SYS
nsc add user -n sys
nsc add account -n A
nsc generate config --mem-resolver --sys-account SYS
...
system_account: AAYTMQXD2ZS56IXBRKB2VHMRXL5OXWSUNYOIHWGSN2Q7X5F4JSMMZKR6
...
```

