### PR TITLE
modified signer params to:

### DIFF
--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -71,7 +71,7 @@ func Test_AddAccountInteractive(t *testing.T) {
 	ts := NewTestStore(t, "test")
 	defer ts.Done(t)
 
-	inputs := []interface{}{"A", true, "2018-01-01", "2050-01-01", ts.OperatorKeyPath}
+	inputs := []interface{}{"A", true, "2018-01-01", "2050-01-01", 0}
 
 	cmd := CreateAddAccountCmd()
 	HoistRootFlags(cmd)
@@ -132,7 +132,8 @@ func Test_AddAccountInteractiveSigningKey(t *testing.T) {
 	_, _, err := ExecuteCmd(createEditOperatorCmd(), "--sk", pk1, "--sk", pk2)
 	require.NoError(t, err)
 
-	inputs := []interface{}{"A", true, "0", "0", string(s1)}
+	// sign with the custom key
+	inputs := []interface{}{"A", true, "0", "0", 1, string(s1)}
 	_, _, err = ExecuteInteractiveCmd(HoistRootFlags(CreateAddAccountCmd()), inputs)
 	require.NoError(t, err)
 

--- a/cmd/addexport_test.go
+++ b/cmd/addexport_test.go
@@ -131,7 +131,7 @@ func TestAddExportInteractive(t *testing.T) {
 	ts.AddAccount(t, "A")
 	ts.AddAccount(t, "B")
 
-	input := []interface{}{0, 0, "foo.>", "Foo Stream", false, ts.OperatorKeyPath}
+	input := []interface{}{0, 0, "foo.>", "Foo Stream", false, 0}
 	cmd := createAddExportCmd()
 	HoistRootFlags(cmd)
 	_, _, err := ExecuteInteractiveCmd(cmd, input, "-i")

--- a/cmd/addimport_test.go
+++ b/cmd/addimport_test.go
@@ -119,7 +119,7 @@ func Test_AddImportInteractive(t *testing.T) {
 
 	cmd := createAddImportCmd()
 	HoistRootFlags(cmd)
-	input := []interface{}{1, false, fp, "my import", "barfoo.>", ts.OperatorKeyPath}
+	input := []interface{}{1, false, fp, "my import", "barfoo.>", 0}
 	_, _, err = ExecuteInteractiveCmd(cmd, input, "-i")
 	require.NoError(t, err)
 
@@ -188,7 +188,7 @@ func Test_AddImport_PublicInteractive(t *testing.T) {
 	cmd := createAddImportCmd()
 	HoistRootFlags(cmd)
 	// B, public, A's pubkey, local sub, service, name test, remote subj "test.foobar.alberto, key
-	input := []interface{}{1, true, apub, "foobar.x", true, "test", "test.foobar.alberto", ts.OperatorKeyPath}
+	input := []interface{}{1, true, apub, "foobar.x", true, "test", "test.foobar.alberto", 0}
 	_, _, err = ExecuteInteractiveCmd(cmd, input, "-i")
 	require.NoError(t, err)
 
@@ -221,7 +221,7 @@ func Test_AddImport_PublicStreamInteractive(t *testing.T) {
 	cmd := createAddImportCmd()
 	HoistRootFlags(cmd)
 	// B, public, A's pubkey, remote sub, stream, name test, local subj "test.foobar.>, key
-	input := []interface{}{1, true, apub, "foobar.>", false, "test", "test.foobar.>", ts.OperatorKeyPath}
+	input := []interface{}{1, true, apub, "foobar.>", false, "test", "test.foobar.>", 0}
 	_, _, err = ExecuteInteractiveCmd(cmd, input, "-i")
 	require.NoError(t, err)
 

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -74,7 +74,7 @@ func Test_AddUserInteractive(t *testing.T) {
 	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", "A")
 	require.NoError(t, err, "account creation")
 
-	inputs := []interface{}{"U", true, "2018-01-01", "2050-01-01", ts.GetAccountKeyPath(t, "A")}
+	inputs := []interface{}{"U", true, "2018-01-01", "2050-01-01", 0}
 
 	cmd := CreateAddUserCmd()
 	HoistRootFlags(cmd)

--- a/cmd/deleteimport_test.go
+++ b/cmd/deleteimport_test.go
@@ -71,7 +71,7 @@ func Test_DeleteImportInteractive(t *testing.T) {
 	ts.AddImport(t, "A", "foo", "B")
 	ts.AddImport(t, "A", "bar", "B")
 
-	input := []interface{}{1, false, 0, ts.OperatorKeyPath}
+	input := []interface{}{1, false, 0, 0}
 	cmd := createDeleteImportCmd()
 	HoistRootFlags(cmd)
 	_, _, err := ExecuteInteractiveCmd(cmd, input)

--- a/cmd/generateactivation_test.go
+++ b/cmd/generateactivation_test.go
@@ -148,7 +148,7 @@ func Test_InteractiveGenerate(t *testing.T) {
 	_, pub, _ := CreateAccountKey(t)
 
 	outpath := filepath.Join(ts.Dir, "token.jwt")
-	inputs := []interface{}{true, 0, "foo", pub, "0", "0", ts.GetAccountKeyPath(t, "A")}
+	inputs := []interface{}{true, 0, "foo", pub, "0", "0", 0}
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 
@@ -169,7 +169,7 @@ func Test_InteractiveExternalKeyGenerate(t *testing.T) {
 
 	_, pub, _ := CreateAccountKey(t)
 
-	inputs := []interface{}{true, 0, "foo", pub, "0", "0", ts.GetAccountKeyPath(t, "A")}
+	inputs := []interface{}{true, 0, "foo", pub, "0", "0", 0}
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 
@@ -191,7 +191,7 @@ func Test_InteractiveMultipleAccountsGenerate(t *testing.T) {
 
 	_, pub, _ := CreateAccountKey(t)
 
-	inputs := []interface{}{0, true, 0, "foo", pub, "0", "0", ts.GetAccountKeyPath(t, "A")}
+	inputs := []interface{}{0, true, 0, "foo", pub, "0", "0", 0}
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs, "-i", "--output-file", outpath)
 	require.NoError(t, err)
 

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -750,3 +750,20 @@ func (ctx *Context) GetAccountKeys(name string) ([]string, error) {
 	keys = append(keys, ac.SigningKeys...)
 	return keys, nil
 }
+
+// GetOperatorKeys returns the public keys for the operator
+// followed by its signing keys
+func (ctx *Context) GetOperatorKeys() ([]string, error) {
+	var keys []string
+	oc, err := ctx.Store.ReadOperatorClaim()
+	if err != nil {
+		return nil, err
+	}
+	if oc == nil {
+		// not found
+		return nil, nil
+	}
+	keys = append(keys, oc.Subject)
+	keys = append(keys, oc.SigningKeys...)
+	return keys, nil
+}


### PR DESCRIPTION
- present the user with a picker of all the keys we know we have
- if some keys are missing, provide an 'other' option
- validate that the entered key matches a signer public key