### PR TITLE
Read/Account/User return nil when resource not found

### DIFF
--- a/cmd/accountcontextparams.go
+++ b/cmd/accountcontextparams.go
@@ -18,6 +18,8 @@ package cmd
 import (
 	"errors"
 
+	"github.com/nats-io/nsc/cmd/store"
+
 	"github.com/spf13/cobra"
 )
 
@@ -46,7 +48,7 @@ func (p *AccountContextParams) SetDefaults(ctx ActionCtx) error {
 	}
 	if p.Name != "" {
 		ac, err := ctx.StoreCtx().Store.ReadAccountClaim(p.Name)
-		if err != nil {
+		if err != nil && !store.IsNotExist(err) {
 			return err
 		}
 		ctx.StoreCtx().Account.PublicKey = ac.Subject

--- a/cmd/addexport_test.go
+++ b/cmd/addexport_test.go
@@ -63,7 +63,6 @@ func Test_AddExportVerify(t *testing.T) {
 func validateAddExports(t *testing.T, ts *TestStore) {
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 
 	require.Len(t, ac.Exports, 4)
 
@@ -102,7 +101,6 @@ func Test_AddExportOperatorLessStore(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Exports, 1)
 	require.Equal(t, "aaaa", string(ac.Exports[0].Subject))
 }
@@ -119,7 +117,6 @@ func Test_AddExportAccountNameRequired(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("B")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Exports, 1)
 	require.Equal(t, "bbbb", ac.Exports[0].Name)
 }
@@ -139,7 +136,6 @@ func TestAddExportInteractive(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Exports, 1)
 	require.Equal(t, "Foo Stream", ac.Exports[0].Name)
 	require.Equal(t, "foo.>", string(ac.Exports[0].Subject))

--- a/cmd/addimport_test.go
+++ b/cmd/addimport_test.go
@@ -93,7 +93,6 @@ func Test_AddImportFromURL(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("B")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Imports, 1)
 	require.Equal(t, token, ac.Imports[0].Token)
 }
@@ -206,7 +205,6 @@ func Test_AddPublicImport(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("B")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Imports, 1)
 }
 

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -166,7 +166,6 @@ func Test_AddUser_WithSK(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 
 	u, err := ts.Store.ReadUserClaim("A", "bb")
 	require.NoError(t, err)

--- a/cmd/deleteexport_test.go
+++ b/cmd/deleteexport_test.go
@@ -68,6 +68,5 @@ func Test_DeleteExportInteractive(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Exports, 1)
 }

--- a/cmd/deleteimport_test.go
+++ b/cmd/deleteimport_test.go
@@ -79,7 +79,6 @@ func Test_DeleteImportInteractive(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("B")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Len(t, ac.Imports, 1)
 }
 

--- a/cmd/describeaccount.go
+++ b/cmd/describeaccount.go
@@ -16,10 +16,7 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/nats-io/jwt"
-	"github.com/nats-io/nsc/cmd/store"
 	"github.com/spf13/cobra"
 )
 
@@ -41,7 +38,7 @@ func createDescribeAccountCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&params.outputFile, "output-file", "o", "--", "output file, '--' is stdout")
-	params.AccountContextParams.BindFlags(cmd)
+	cmd.Flags().StringVarP(&params.AccountContextParams.Name, "name", "n", "", "account name")
 
 	return cmd
 }
@@ -72,16 +69,12 @@ func (p *DescribeAccountParams) Load(ctx ActionCtx) error {
 		return err
 	}
 
-	if !ctx.StoreCtx().Store.Has(store.Accounts, p.AccountContextParams.Name, store.JwtName(p.AccountContextParams.Name)) {
-		return fmt.Errorf("account %q is not defined in the current context", p.AccountContextParams.Name)
-	}
 	ac, err := ctx.StoreCtx().Store.ReadAccountClaim(p.AccountContextParams.Name)
 	if err != nil {
 		return err
 	}
-	if ac != nil {
-		p.AccountClaims = *ac
-	}
+	p.AccountClaims = *ac
+
 	return nil
 }
 

--- a/cmd/describeaccount_test.go
+++ b/cmd/describeaccount_test.go
@@ -97,7 +97,7 @@ func TestDescribeAccount_MultipleWithFlag(t *testing.T) {
 
 	pub := ts.GetAccountPublicKey(t, "B")
 
-	stdout, _, err := ExecuteCmd(createDescribeAccountCmd(), "--account", "B")
+	stdout, _, err := ExecuteCmd(createDescribeAccountCmd(), "--name", "B")
 	require.NoError(t, err)
 	require.Contains(t, stdout, pub)
 	require.Contains(t, stdout, " B ")
@@ -110,7 +110,7 @@ func TestDescribeAccount_MultipleWithBadAccount(t *testing.T) {
 	ts.AddAccount(t, "A")
 	ts.AddAccount(t, "B")
 
-	_, _, err := ExecuteCmd(createDescribeAccountCmd(), "--account", "C")
+	_, _, err := ExecuteCmd(createDescribeAccountCmd(), "--name", "C")
 	require.Error(t, err)
 }
 

--- a/cmd/describeoperator.go
+++ b/cmd/describeoperator.go
@@ -42,7 +42,7 @@ func createDescribeOperatorCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVarP(&params.outputFile, "output-file", "o", "--", "output file, '--' is stdout")
-	cmd.Flags().StringVarP(&params.name, "operator", "r", "", "operator name")
+	cmd.Flags().StringVarP(&params.name, "name", "n", "", "operator name")
 
 	return cmd
 }

--- a/cmd/describeoperator_test.go
+++ b/cmd/describeoperator_test.go
@@ -72,7 +72,7 @@ func TestDescribeOperator_MultipleWithFlag(t *testing.T) {
 
 	pub := ts.GetOperatorPublicKey(t)
 
-	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--operator", "B")
+	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--name", "B")
 	require.NoError(t, err)
 	require.Contains(t, stdout, pub)
 	require.Contains(t, stdout, " B ")
@@ -82,7 +82,7 @@ func TestDescribeOperator_MultipleWithBadOperator(t *testing.T) {
 	ts := NewTestStore(t, "operator")
 	defer ts.Done(t)
 
-	_, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--operator", "C")
+	_, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--name", "C")
 	require.Error(t, err)
 }
 
@@ -90,7 +90,7 @@ func TestDescribeOperator_AccountServerURL(t *testing.T) {
 	ts := NewTestStore(t, "O")
 	defer ts.Done(t)
 
-	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--operator", "O")
+	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--name", "O")
 	require.NoError(t, err)
 	require.NotContains(t, stdout, "Account JWT Server")
 
@@ -102,7 +102,7 @@ func TestDescribeOperator_AccountServerURL(t *testing.T) {
 	err = ts.Store.StoreClaim([]byte(token))
 	require.NoError(t, err)
 
-	stdout, _, err = ExecuteCmd(createDescribeOperatorCmd(), "--operator", "O")
+	stdout, _, err = ExecuteCmd(createDescribeOperatorCmd(), "--name", "O")
 	require.NoError(t, err)
 	require.Contains(t, stdout, u)
 }
@@ -111,7 +111,7 @@ func TestDescribeOperator_OperatorServiceURLs(t *testing.T) {
 	ts := NewTestStore(t, "O")
 	defer ts.Done(t)
 
-	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--operator", "O")
+	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--name", "O")
 	require.NoError(t, err)
 	require.NotContains(t, stdout, "Operator Service URLs")
 
@@ -125,7 +125,7 @@ func TestDescribeOperator_OperatorServiceURLs(t *testing.T) {
 	err = ts.Store.StoreClaim([]byte(token))
 	require.NoError(t, err)
 
-	stdout, _, err = ExecuteCmd(createDescribeOperatorCmd(), "--operator", "O")
+	stdout, _, err = ExecuteCmd(createDescribeOperatorCmd(), "--name", "O")
 	require.NoError(t, err)
 	require.Contains(t, stdout, "Operator Service URLs")
 	require.Contains(t, stdout, "nats://localhost:4222")

--- a/cmd/describeuser.go
+++ b/cmd/describeuser.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 
 	"github.com/nats-io/jwt"
-	"github.com/nats-io/nsc/cmd/store"
 	"github.com/spf13/cobra"
 )
 
@@ -94,10 +93,6 @@ func (p *DescribeUserParams) Load(ctx ActionCtx) error {
 
 	if p.user == "" {
 		return fmt.Errorf("user is required")
-	}
-
-	if !ctx.StoreCtx().Store.Has(store.Accounts, p.AccountContextParams.Name, store.Users, store.JwtName(p.user)) {
-		return fmt.Errorf("user %q not found", p.user)
 	}
 
 	uc, err := ctx.StoreCtx().Store.ReadUserClaim(p.AccountContextParams.Name, p.user)

--- a/cmd/editaccount_test.go
+++ b/cmd/editaccount_test.go
@@ -60,7 +60,6 @@ func Test_EditAccount_Tag(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 
 	require.Len(t, ac.Tags, 3)
 	require.ElementsMatch(t, ac.Tags, []string{"a", "b", "c"})
@@ -79,7 +78,6 @@ func Test_EditAccount_RmTag(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 
 	require.Len(t, ac.Tags, 1)
 	require.ElementsMatch(t, ac.Tags, []string{"c"})
@@ -102,7 +100,6 @@ func Test_EditAccount_Times(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Equal(t, start, ac.NotBefore)
 	require.Equal(t, expiry, ac.Expires)
 }
@@ -118,7 +115,6 @@ func Test_EditAccountLimits(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Equal(t, int64(5), ac.Limits.Conn)
 	require.Equal(t, int64(31), ac.Limits.LeafNodeConn)
 	require.Equal(t, int64(1000*1000*10), ac.Limits.Data)
@@ -141,7 +137,6 @@ func Test_EditAccountSigningKeys(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.Contains(t, ac.SigningKeys, pk)
 	require.Contains(t, ac.SigningKeys, pk2)
 
@@ -149,8 +144,6 @@ func Test_EditAccountSigningKeys(t *testing.T) {
 	require.NoError(t, err)
 
 	ac, err = ts.Store.ReadAccountClaim("A")
-	require.NoError(t, err)
-	require.NotNil(t, ac)
 	require.NoError(t, err)
 	require.NotContains(t, ac.SigningKeys, pk)
 }

--- a/cmd/generateactivation_test.go
+++ b/cmd/generateactivation_test.go
@@ -219,7 +219,6 @@ func Test_GenerateActivationUsingSigningKey(t *testing.T) {
 
 	ac, err := ts.Store.ReadAccountClaim("A")
 	require.NoError(t, err)
-	require.NotNil(t, ac)
 
 	d, err := ioutil.ReadFile(outpath)
 	require.NoError(t, err)

--- a/cmd/generateserverconfig.go
+++ b/cmd/generateserverconfig.go
@@ -185,9 +185,6 @@ func (p *GenerateServerConfigParams) Validate(ctx ActionCtx) error {
 		if err != nil {
 			return fmt.Errorf("error reading account %q: %v", p.sysAccount, err)
 		}
-		if ac == nil {
-			return fmt.Errorf("account %q doesn't exist", p.sysAccount)
-		}
 		if err := p.generator.SetSystemAccount(ac.Subject); err != nil {
 			return err
 		}

--- a/cmd/importcollector.go
+++ b/cmd/importcollector.go
@@ -97,6 +97,10 @@ func GetAllExports() ([]AccountExport, error) {
 		for _, a := range accounts {
 			ac, err := s.ReadAccountClaim(a)
 			if err != nil {
+				if store.IsNotExist(err) {
+					// ignore it and move on
+					continue
+				}
 				return nil, err
 			}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -131,10 +131,6 @@ func createListAccountsCmd() *cobra.Command {
 					i.err = err
 					continue
 				}
-				if ac == nil {
-					i.err = fmt.Errorf("%q jwt not found", v)
-					continue
-				}
 				i.claims = ac
 			}
 			cmd.Println(listEntities("Accounts", infos, config.Account))

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -126,10 +126,7 @@ func createFlagTable() *cobra.Command {
 					cmds.addCmd(v)
 				}
 			}
-
-			cmd.Println(cmds.render())
-
-			return nil
+			return Write("--", []byte(cmds.render()))
 		},
 	}
 	return cmd

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -400,12 +400,6 @@ func (ts *TestStore) GetAccountKeyPath(t *testing.T, name string) string {
 	return ts.KeyStore.GetKeyPath(sc.Subject)
 }
 
-func (ts *TestStore) GetClusterKeyPath(t *testing.T, name string) string {
-	sc, err := ts.Store.ReadClusterClaim(name)
-	require.NoError(t, err)
-	return ts.KeyStore.GetKeyPath(sc.Subject)
-}
-
 func (ts *TestStore) GetOperatorPublicKey(t *testing.T) string {
 	oc, err := ts.Store.ReadOperatorClaim()
 	require.NoError(t, err)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -140,6 +140,9 @@ func (p *ValidateCmdParams) Validate(ctx ActionCtx) error {
 	for _, v := range p.accounts {
 		ac, err := ctx.StoreCtx().Store.ReadAccountClaim(v)
 		if err != nil {
+			if store.IsNotExist(err) {
+				continue
+			}
 			return err
 		}
 		aci := p.validateJWT(ac)


### PR DESCRIPTION
- Fixed and simplified reading of accounts/users. The store will now return an error if the account does not exist, and allows downstream to check if the issue is a resource not existing

- Fixed discrepancies for nsc descrie account requiring '-a' flag instead of '-n'.