### PR TITLE
Added friendly names to account imports

### DIFF
--- a/cmd/describeoperator_test.go
+++ b/cmd/describeoperator_test.go
@@ -67,15 +67,12 @@ func TestDescribeOperator_MultipleWithFlag(t *testing.T) {
 	ts.AddOperator(t, "A")
 	ts.AddOperator(t, "B")
 
-	err := GetConfig().SetOperator("B")
-	require.NoError(t, err)
-
 	pub := ts.GetOperatorPublicKey(t)
 
 	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd(), "--name", "B")
 	require.NoError(t, err)
-	require.Contains(t, stdout, pub)
 	require.Contains(t, stdout, " B ")
+	require.Contains(t, stdout, pub)
 }
 
 func TestDescribeOperator_MultipleWithBadOperator(t *testing.T) {

--- a/cmd/describer.go
+++ b/cmd/describer.go
@@ -201,7 +201,7 @@ func (i *ImportDescriber) Brief(table *tablewriter.Table) {
 	}
 
 	if i.Token == "" {
-		table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, "", i.Account, "Yes")
+		table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, "", Wide(i.Account), "Yes")
 		return
 	}
 	expiration := ""
@@ -211,7 +211,7 @@ func (i *ImportDescriber) Brief(table *tablewriter.Table) {
 	} else {
 		expiration = RenderDate(ac.Expires)
 	}
-	table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, expiration, i.Account, "No")
+	table.AddRow(i.Name, strings.Title(i.Type.String()), remote, local, expiration, Wide(i.Account), "No")
 }
 
 func (i *ImportDescriber) IsRemoteImport() bool {

--- a/cmd/friendlynamecollector.go
+++ b/cmd/friendlynamecollector.go
@@ -27,6 +27,7 @@ import (
 func friendlyNames(operator string) (map[string]string, error) {
 	m := make(map[string]string)
 	operators := config.ListOperators()
+	hasMany := len(operators) > 1
 	for _, o := range operators {
 		if o == "" {
 			continue
@@ -53,7 +54,7 @@ func friendlyNames(operator string) (map[string]string, error) {
 				return nil, err
 			}
 			name := ac.Name
-			if oc.Name != operator {
+			if hasMany && oc.Name != operator {
 				name = fmt.Sprintf("%s/%s", oc.Name, ac.Name)
 			}
 			m[ac.Subject] = name

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,7 +34,6 @@ const TestEnv = "NSC_TEST"
 
 var KeyPathFlag string
 var InteractiveFlag bool
-var WideFlag bool
 var quietMode bool
 
 var cfgFile string
@@ -170,7 +169,6 @@ func init() {
 func HoistRootFlags(cmd *cobra.Command) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&KeyPathFlag, "private-key", "K", "", "private key")
 	cmd.PersistentFlags().BoolVarP(&InteractiveFlag, "interactive", "i", false, "ask questions for various settings")
-
 	return cmd
 }
 


### PR DESCRIPTION
Describing an account shows import source accounts as simple names