### PR TITLE
interactive operator edit didn't prompt for signing key

### DIFF
--- a/cmd/editoperator.go
+++ b/cmd/editoperator.go
@@ -164,7 +164,11 @@ func (p *EditOperatorParams) PostInteractive(ctx ActionCtx) error {
 		}
 	}
 
-	return p.signingKeys.Edit()
+	if err := p.signingKeys.Edit(); err != nil {
+		return err
+	}
+
+	return p.SignerParams.Edit(ctx)
 }
 
 func (p *EditOperatorParams) Validate(ctx ActionCtx) error {


### PR DESCRIPTION
Fixed an issue where editing an operator didn't required the main key to be present to sign the edits - The editor never prompted for the key to sign it.