### PR TITLE
support managed operators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_script:
 #- megacheck $EXCLUDE_VENDOR
 
 script:
-- ./scripts/cov.sh TRAVIS
+#- ./scripts/cov.sh TRAVIS
+- go test ./...
 
 after_success:
 - git reset --hard

--- a/cli/testprompts.go
+++ b/cli/testprompts.go
@@ -64,7 +64,7 @@ func (t *TestPrompts) PromptSecret(m string) (string, error) {
 }
 
 func (t *TestPrompts) PromptChoices(m string, value string, choices []string) (int, error) {
-	t.logInputs("choices", m, fmt.Sprintf("[%s]", strings.Join(choices, ", ")))
+	t.logInputs("choices", m, fmt.Sprintf("[%s]", strings.Join(choices, ",\n\t")))
 	val := t.inputs[t.count].(int)
 	t.logInputs("choices", "   selection", fmt.Sprintf("%d (%s)", val, choices[val]))
 	t.count = t.count + 1

--- a/cmd/accountcontextparams.go
+++ b/cmd/accountcontextparams.go
@@ -47,11 +47,7 @@ func (p *AccountContextParams) SetDefaults(ctx ActionCtx) error {
 		}
 	}
 	if p.Name != "" {
-		ac, err := ctx.StoreCtx().Store.ReadAccountClaim(p.Name)
-		if err != nil && !store.IsNotExist(err) {
-			return err
-		}
-		ctx.StoreCtx().Account.PublicKey = ac.Subject
+		return p.setAccount(ctx, p.Name)
 	}
 
 	return nil
@@ -59,12 +55,11 @@ func (p *AccountContextParams) SetDefaults(ctx ActionCtx) error {
 
 func (p *AccountContextParams) Edit(ctx ActionCtx) error {
 	var err error
-	p.Name, err = ctx.StoreCtx().PickAccount(p.Name)
+	name, err := ctx.StoreCtx().PickAccount(p.Name)
 	if err != nil {
 		return err
 	}
-	ctx.StoreCtx().Account.Name = p.Name
-	return nil
+	return p.setAccount(ctx, name)
 }
 
 func (p *AccountContextParams) Validate(ctx ActionCtx) error {
@@ -73,5 +68,15 @@ func (p *AccountContextParams) Validate(ctx ActionCtx) error {
 		ctx.CurrentCmd().SilenceUsage = false
 		return errors.New("an account is required")
 	}
+	return nil
+}
+
+func (p *AccountContextParams) setAccount(ctx ActionCtx, name string) error {
+	ac, err := ctx.StoreCtx().Store.ReadAccountClaim(name)
+	if err != nil && !store.IsNotExist(err) {
+		return err
+	}
+	p.Name = name
+	ctx.StoreCtx().Account.PublicKey = ac.Subject
 	return nil
 }

--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -41,7 +41,7 @@ func Test_AddAccount(t *testing.T) {
 		{CreateAddAccountCmd(), []string{"add", "account", "--name", "A"}, nil, []string{"Generated account key", "added account"}, false},
 		{CreateAddAccountCmd(), []string{"add", "account", "--name", "A"}, nil, []string{"the account \"A\" already exists"}, true},
 		{CreateAddAccountCmd(), []string{"add", "account", "--name", "B", "--public-key", bar}, nil, nil, false},
-		{CreateAddAccountCmd(), []string{"add", "account", "--name", "X", "--public-key", cpk}, nil, []string{"invalid account key"}, true},
+		{CreateAddAccountCmd(), []string{"add", "account", "--name", "X", "--public-key", cpk}, nil, []string{"specified key is not a valid account nkey"}, true},
 		{CreateAddAccountCmd(), []string{"add", "account", "--name", "badexp", "--expiry", "30d"}, nil, nil, false},
 	}
 
@@ -111,13 +111,15 @@ func validateAddAccountClaims(t *testing.T, ts *TestStore) {
 	require.Equal(t, expire, ac.Expires)
 }
 
-func Test_AddAccountOperatorLessStore(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+func Test_AddAccountManagedStore(t *testing.T) {
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
 	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", "A", "--start", "2018-01-01", "--expiry", "2050-01-01")
 	require.NoError(t, err)
-	validateAddAccountClaims(t, ts)
 }
 
 func Test_AddAccountInteractiveSigningKey(t *testing.T) {

--- a/cmd/addexport.go
+++ b/cmd/addexport.go
@@ -81,7 +81,6 @@ toolName add export --name myexport --subject a.b --service`
 
 func (p *AddExportParams) SetDefaults(ctx ActionCtx) error {
 	p.AccountContextParams.SetDefaults(ctx)
-
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 
 	p.export.TokenReq = p.private

--- a/cmd/addexport_test.go
+++ b/cmd/addexport_test.go
@@ -91,8 +91,11 @@ func validateAddExports(t *testing.T, ts *TestStore) {
 	require.True(t, privbar.TokenReq)
 }
 
-func Test_AddExportOperatorLessStore(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+func Test_AddExportManagedStore(t *testing.T) {
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
 	ts.AddAccount(t, "A")
@@ -106,11 +109,16 @@ func Test_AddExportOperatorLessStore(t *testing.T) {
 }
 
 func Test_AddExportAccountNameRequired(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
 	ts.AddAccount(t, "A")
+	t.Log("A", ts.GetAccountPublicKey(t, "A"))
 	ts.AddAccount(t, "B")
+	t.Log("B", ts.GetAccountPublicKey(t, "B"))
 
 	_, _, err := ExecuteCmd(createAddExportCmd(), "--subject", "bbbb")
 	require.NoError(t, err)

--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -162,3 +162,38 @@ func Test_ImportOperatorFromURL(t *testing.T) {
 	require.Equal(t, pub, oo.Subject)
 	require.True(t, ts.Store.IsManaged())
 }
+
+func Test_AddOperatorWithKey(t *testing.T) {
+	ts := NewEmptyStore(t)
+	defer ts.Done(t)
+
+	seed, pub, _ := CreateOperatorKey(t)
+	cmd := createAddOperatorCmd()
+	HoistRootFlags(cmd)
+	_, _, err := ExecuteCmd(cmd, "--name", "T", "-K", string(seed))
+	require.NoError(t, err)
+
+	ts.SwitchOperator(t, "T")
+	oc, err := ts.Store.ReadOperatorClaim()
+	require.NoError(t, err)
+	require.Equal(t, pub, oc.Subject)
+	require.Equal(t, pub, oc.Issuer)
+}
+
+func Test_AddOperatorWithKeyInteractive(t *testing.T) {
+	ts := NewEmptyStore(t)
+	defer ts.Done(t)
+
+	seed, pub, _ := CreateOperatorKey(t)
+	cmd := createAddOperatorCmd()
+	HoistRootFlags(cmd)
+
+	args := []interface{}{false, "T", "0", "0", false, string(seed)}
+	_, _, err := ExecuteInteractiveCmd(cmd, args)
+	require.NoError(t, err)
+
+	ts.SwitchOperator(t, "T")
+	oc, err := ts.Store.ReadOperatorClaim()
+	require.NoError(t, err)
+	require.Equal(t, pub, oc.Subject)
+}

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -116,8 +116,11 @@ func validateAddUserClaims(t *testing.T, ts *TestStore) {
 	require.Equal(t, expire, sc.Expires)
 }
 
-func Test_AddUserOperatorLessStore(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+func Test_AddUserManagedStore(t *testing.T) {
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
 	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", "A", "--start", "2018-01-01", "--expiry", "2050-01-01")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -444,3 +444,18 @@ func OperatorJwtURL(oc *jwt.OperatorClaims) (string, error) {
 	}
 	return OperatorJwtURLFromString(oc.AccountServerURL)
 }
+
+func ValidSigner(kp nkeys.KeyPair, signers []string) (bool, error) {
+	pk, err := kp.PublicKey()
+	if err != nil {
+		return false, err
+	}
+	ok := false
+	for _, v := range signers {
+		if pk == v {
+			ok = true
+			break
+		}
+	}
+	return ok, nil
+}

--- a/cmd/deleteexport_test.go
+++ b/cmd/deleteexport_test.go
@@ -52,18 +52,22 @@ func Test_DeleteExportAccountRequired(t *testing.T) {
 	require.Contains(t, err.Error(), "account is required")
 }
 
-func Test_DeleteExportInteractive(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+func Test_DeleteExportInteractiveManagedStore(t *testing.T) {
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
 	ts.AddExport(t, "A", jwt.Stream, "foo", true)
 	ts.AddExport(t, "A", jwt.Stream, "baz", true)
 	ts.AddAccount(t, "B")
 
-	input := []interface{}{0, 0, ts.GetAccountKeyPath(t, "A")}
 	cmd := createDeleteExportCmd()
 	HoistRootFlags(cmd)
-	_, _, err := ExecuteInteractiveCmd(cmd, input, "-i")
+
+	input := []interface{}{0, 0, ts.GetAccountKeyPath(t, "A")}
+	_, _, err := ExecuteInteractiveCmd(cmd, input)
 	require.NoError(t, err)
 
 	ac, err := ts.Store.ReadAccountClaim("A")

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -181,7 +181,7 @@ func (p *PushCmdParams) PostInteractive(ctx ActionCtx) error {
 
 func (p *PushCmdParams) Validate(ctx ActionCtx) error {
 	if p.ASU == "" {
-		return errors.New("no account server url was provided by the operator jwt or to nsc")
+		return errors.New("no account server url was provided by the operator jwt")
 	}
 
 	if err := p.validURL(p.ASU); err != nil {

--- a/cmd/revokeuser_test.go
+++ b/cmd/revokeuser_test.go
@@ -97,7 +97,7 @@ func TestRevokeUserAt(t *testing.T) {
 }
 
 func Test_RevokeUserAccountNameRequired(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+	ts := NewTestStore(t, "test")
 	defer ts.Done(t)
 
 	ts.AddAccount(t, "A")

--- a/cmd/signerparams.go
+++ b/cmd/signerparams.go
@@ -151,3 +151,9 @@ func (p *SignerParams) Resolve(ctx ActionCtx) error {
 
 	return err
 }
+
+func (p *SignerParams) ForceManagedAccountKey(ctx ActionCtx, kp nkeys.KeyPair) {
+	if ctx.StoreCtx().Store.IsManaged() && p.signerKP == nil {
+		p.signerKP = kp
+	}
+}

--- a/cmd/signerparams_test.go
+++ b/cmd/signerparams_test.go
@@ -99,8 +99,12 @@ func Test_SignerParams(t *testing.T) {
 }
 
 func Test_ManagedSignerParams(t *testing.T) {
-	ts := NewTestStoreWithOperator(t, "test", nil)
+	as, m := RunTestAccountServer(t)
+	defer as.Close()
+
+	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
+
 	require.True(t, ts.Store.IsManaged())
 	require.Nil(t, ts.OperatorKey)
 

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -441,7 +441,7 @@ func (s *Store) syncRemoteAccount(u string) (int, []byte, error) {
 }
 
 func (s *Store) pushRemoteAccount(u string, data []byte) (int, []byte, error) {
-	resp, err := http.Post(u, "application/text", bytes.NewReader(data))
+	resp, err := http.Post(u, "application/jwt", bytes.NewReader(data))
 	if err != nil {
 		return 0, nil, err
 	}

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -18,14 +18,19 @@
 package store
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/nats-io/jwt"
 	"github.com/nats-io/nkeys"
@@ -43,6 +48,93 @@ const Servers = "servers"
 var standardDirs = []string{Accounts}
 
 var ErrNotExist = errors.New("resource does not exist")
+
+func OK(status int) bool {
+	return status == http.StatusOK
+}
+
+func Pending(status int) bool {
+	return status > 200 && status < 300
+}
+
+type Status struct {
+	HttpStatus int
+	Data       []byte
+	Err        error
+}
+
+func (s *Status) OK() bool {
+	return s.HttpStatus == http.StatusOK
+}
+
+type RemoteStoreStatus struct {
+	Push Status
+	Sync Status
+	Err  error
+}
+
+func (r *RemoteStoreStatus) HasError() bool {
+	return r.Err != nil || r.Sync.Err != nil || r.Push.Err != nil
+}
+
+func (r *RemoteStoreStatus) GetError() error {
+	if r.Err != nil {
+		return r.Err
+	}
+	if r.Sync.Err != nil {
+		return r.Sync.Err
+	}
+	if r.Push.Err != nil {
+		return r.Push.Err
+	}
+	return nil
+}
+
+func (r *RemoteStoreStatus) GetPushMessage() []byte {
+	return r.Push.Data
+}
+
+func (r *RemoteStoreStatus) OK() bool {
+	return r.GetError() == nil && r.Sync.OK() && r.Push.OK()
+}
+
+func (r *RemoteStoreStatus) Error() string {
+	if r.Err != nil {
+		return r.Err.Error()
+	}
+	if r.Push.Err != nil {
+		return r.Push.Err.Error()
+	}
+	if r.Sync.Err != nil {
+		return r.Sync.Err.Error()
+	}
+
+	if !r.Push.OK() {
+		if r.Push.HttpStatus > 200 && r.Push.HttpStatus < 300 {
+			m := "account push succeeded, but is not yet available - enter 'nsc sync' to synchronize with the remote server"
+			if len(r.Push.Data) > 0 {
+				m = fmt.Sprintf("%s\n%s\n", m, string(r.Push.Data))
+			}
+			return m
+		}
+		if r.Push.HttpStatus < 200 || r.Push.HttpStatus > 299 {
+			m := fmt.Sprintf("account push failed with %s", http.StatusText(r.Push.HttpStatus))
+			if len(r.Push.Data) > 0 {
+				m = fmt.Sprintf("%s\n%s\n", m, string(r.Push.Data))
+			}
+			return m
+		}
+	}
+	if !r.Sync.OK() {
+		return fmt.Sprintf("account sync failed with %s", http.StatusText(r.Push.HttpStatus))
+	}
+
+	if r.OK() && len(r.Push.Data) > 0 {
+		return fmt.Sprintf("account synchronization succeeded\n%s\n", string(r.Push.Data))
+	}
+
+	return ""
+}
 
 // Store is a directory that contains nsc assets
 type Store struct {
@@ -321,19 +413,116 @@ func (s *Store) ListEntries(name ...string) ([]string, error) {
 	return entries, nil
 }
 
-func (s *Store) StoreClaim(data []byte) error {
+func (s *Store) ClaimType(data []byte) (*jwt.ClaimType, error) {
 	// Decode the jwt to figure out where it goes
 	gc, err := jwt.DecodeGeneric(string(data))
 	if err != nil {
-		return fmt.Errorf("invalid jwt: %v", err)
+		return nil, fmt.Errorf("invalid jwt: %v", err)
 	}
 	if gc.Name == "" {
-		return errors.New("jwt claim doesn't have a name")
+		return nil, errors.New("jwt claim doesn't have a name")
+	}
+	return &gc.Type, nil
+}
+
+func (s *Store) syncRemoteAccount(u string) (int, []byte, error) {
+	c := &http.Client{Timeout: time.Second * 5}
+	r, err := c.Get(u)
+	if err != nil {
+		return 0, nil, fmt.Errorf("error loading %q: %v", u, err)
+	}
+	defer r.Body.Close()
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, r.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("error reading response from %q: %v", u, err)
+	}
+	return r.StatusCode, buf.Bytes(), nil
+}
+
+func (s *Store) pushRemoteAccount(u string, data []byte) (int, []byte, error) {
+	resp, err := http.Post(u, "application/text", bytes.NewReader(data))
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	message, err := ioutil.ReadAll(resp.Body)
+	return resp.StatusCode, message, err
+}
+
+func (s *Store) handleManagedAccount(data []byte) *RemoteStoreStatus {
+	var status RemoteStoreStatus
+	ac, err := jwt.DecodeAccountClaims(string(data))
+	if err != nil {
+		status.Err = fmt.Errorf("error decoding account claim")
+		return &status
+	}
+
+	oc, err := s.ReadOperatorClaim()
+	if err != nil {
+		status.Err = fmt.Errorf("unable to push to the operator - failed to read operator claim: %v", err)
+		return &status
+	}
+	if oc.AccountServerURL == "" {
+		status.Err = errors.New("unable to push to the operator - operator jwt doesn't set account server url")
+		return &status
+	}
+
+	u, err := url.Parse(oc.AccountServerURL)
+	if err != nil {
+		status.Err = fmt.Errorf("unable to push to the operator - failed to parse account server url (%q): %v", oc.AccountServerURL, err)
+		return &status
+	}
+	u.Path = filepath.Join(u.Path, "accounts", ac.Subject)
+	status.Push.HttpStatus, status.Push.Data, status.Push.Err = s.pushRemoteAccount(u.String(), data)
+	if status.Push.Err != nil {
+		return &status
+	}
+
+	if status.Push.OK() {
+		status.Sync.HttpStatus, status.Sync.Data, err = s.syncRemoteAccount(u.String())
+	}
+	return &status
+}
+
+func (s *Store) StoreClaim(data []byte) error {
+	ct, err := s.ClaimType(data)
+	if err != nil {
+		return err
+	}
+	if *ct == jwt.AccountClaim && s.IsManaged() {
+		rs := s.handleManagedAccount(data)
+		if rs.HasError() {
+			return rs
+		}
+		if rs.OK() {
+			if err := s.StoreRaw(rs.Sync.Data); err != nil {
+				return err
+			}
+			if len(rs.Push.Data) == 0 {
+				// nothing to display to the user
+				return nil
+			}
+		}
+		return rs
+	} else {
+		return s.StoreRaw(data)
+	}
+}
+
+func (s *Store) StoreRaw(data []byte) error {
+	ct, err := s.ClaimType(data)
+	if err != nil {
+		return err
 	}
 	var path string
-	switch gc.Type {
+	switch *ct {
 	case jwt.AccountClaim:
-		path = filepath.Join(Accounts, gc.Name, JwtName(gc.Name))
+		ac, err := jwt.DecodeAccountClaims(string(data))
+		if err != nil {
+			return err
+		}
+		path = filepath.Join(Accounts, ac.Name, JwtName(ac.Name))
 	case jwt.UserClaim:
 		uc, err := jwt.DecodeUserClaims(string(data))
 		if err != nil {
@@ -363,38 +552,15 @@ func (s *Store) StoreClaim(data []byte) error {
 		if account == "" {
 			return fmt.Errorf("account with public key %q is not in the store", issuer)
 		}
-		path = filepath.Join(Accounts, account, Users, JwtName(gc.Name))
-	case jwt.ServerClaim:
-		issuer := gc.Issuer
-		var cluster string
-		infos, err := s.List(Clusters)
+		path = filepath.Join(Accounts, account, Users, JwtName(uc.Name))
+	case jwt.OperatorClaim:
+		oc, err := jwt.DecodeOperatorClaims(string(data))
 		if err != nil {
 			return err
 		}
-		for _, i := range infos {
-			if i.IsDir() {
-				c, err := s.LoadClaim(Clusters, i.Name(), JwtName(i.Name()))
-				if err != nil {
-					return err
-				}
-				if c != nil {
-					if c.Subject == issuer {
-						cluster = i.Name()
-						break
-					}
-				}
-			}
-		}
-		if cluster == "" {
-			return fmt.Errorf("cluster with public key %q is not in the store", issuer)
-		}
-		path = filepath.Join(Clusters, cluster, Servers, JwtName(gc.Name))
-	case jwt.ClusterClaim:
-		path = filepath.Join(Clusters, gc.Name, JwtName(gc.Name))
-	case jwt.OperatorClaim:
-		path = JwtName(gc.Name)
+		path = JwtName(oc.Name)
 	default:
-		return fmt.Errorf("unsuported store claim type: %s", gc.Type)
+		return fmt.Errorf("unsuported store claim type: %s", *ct)
 	}
 
 	return s.Write(data, path)

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -245,7 +245,7 @@ func (ts *TestStore) GetStoresRoot() string {
 func (ts *TestStore) AddAccount(t *testing.T, accountName string) {
 	if !ts.Store.Has(store.Accounts, accountName, store.JwtName(accountName)) {
 		_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", accountName)
-		require.NoError(t, err, "account creation")
+		require.NoError(t, err)
 	}
 }
 
@@ -254,14 +254,14 @@ func (ts *TestStore) AddAccountWithSigner(t *testing.T, accountName string, sk n
 		seed, err := sk.Seed()
 		require.NoError(t, err)
 		_, _, err = ExecuteCmd(HoistRootFlags(CreateAddAccountCmd()), "--name", accountName, "-K", string(seed))
-		require.NoError(t, err, "account creation")
+		require.NoError(t, err)
 	}
 }
 
 func (ts *TestStore) AddUser(t *testing.T, accountName string, userName string) {
 	ts.AddAccount(t, accountName)
 	_, _, err := ExecuteCmd(CreateAddUserCmd(), "--account", accountName, "--name", userName)
-	require.NoError(t, err, "user creation")
+	require.NoError(t, err)
 }
 
 func (ts *TestStore) AddUserWithSigner(t *testing.T, accountName string, userName string, sk nkeys.KeyPair) {
@@ -269,7 +269,7 @@ func (ts *TestStore) AddUserWithSigner(t *testing.T, accountName string, userNam
 	seed, err := sk.Seed()
 	require.NoError(t, err)
 	_, _, err = ExecuteCmd(HoistRootFlags(CreateAddUserCmd()), "--account", accountName, "--name", userName, "-K", string(seed))
-	require.NoError(t, err, "user creation")
+	require.NoError(t, err)
 }
 
 func (ts *TestStore) AddExport(t *testing.T, accountName string, kind jwt.ExportType, subject string, public bool) {


### PR DESCRIPTION
Typical operations in NSC require a signer that is locally available. To support a managed operator, the signer will never be available. Support for a managed operator is baked into the JWT via its Account Server URL field.

A managed operator accepts a self-signed account JWT on an account JWT server and re-signs it with the operator key.

The change for supporting a managed operator, the store function will check if the operator is managed, if it is, it will push the account JWT to the account server defined by the operator (a requirement for a managed operator). If pushed succeeds, it then queries the operator for the JWT which is now signed by the operator (with limits injected). The signed JWT is then stored on disk.

It is possible for an operator to accept an account (where additional steps may need to happen before the process is complete). At that point, a 'sync' command will pull the signed JWT at a later time in response to the user.