### PR TITLE
cwd awareness

### DIFF
--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -69,7 +69,7 @@ func TestImportOperator(t *testing.T) {
 	var info store.Info
 	json.Unmarshal(d, &info)
 	require.True(t, info.Managed)
-	require.Equal(t, "O", info.EntityName)
+	require.Equal(t, "O", info.Name)
 
 	target := filepath.Join(ts.Dir, "store", "O", "O.jwt")
 	require.FileExists(t, target)

--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -223,7 +223,6 @@ func (p *AddUserParams) Run(ctx ActionCtx) error {
 	if err := p.Entity.StoreKeys(p.AccountContextParams.Name); err != nil {
 		return err
 	}
-
 	if err := p.Entity.GenerateClaim(p.signerKP, ctx); err != nil {
 		return err
 	}

--- a/cmd/contextconfig.go
+++ b/cmd/contextconfig.go
@@ -33,9 +33,11 @@ type ContextConfig struct {
 
 func NewContextConfig(storeRoot string) (*ContextConfig, error) {
 	ctx := ContextConfig{}
-	root := GetCwdStoresRoot()
-	if root != "" {
-		ctx.setStoreRoot(root)
+	dc := GetCwdCtx()
+	if dc != nil {
+		ctx = *dc
+		config.SetDefaults()
+		ctx.setStoreRoot(ctx.StoreRoot)
 		return &ctx, nil
 	}
 

--- a/cmd/contextconfig.go
+++ b/cmd/contextconfig.go
@@ -33,6 +33,12 @@ type ContextConfig struct {
 
 func NewContextConfig(storeRoot string) (*ContextConfig, error) {
 	ctx := ContextConfig{}
+	root := GetCwdStoresRoot()
+	if root != "" {
+		ctx.setStoreRoot(root)
+		return &ctx, nil
+	}
+
 	if err := ctx.setStoreRoot(storeRoot); err != nil {
 		return nil, err
 	}

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/nats-io/jwt"
+
 	"github.com/mitchellh/go-homedir"
 	"github.com/nats-io/nsc/cmd/store"
 )
@@ -70,7 +72,7 @@ func GetCwdCtx() *ContextConfig {
 	}
 	if ok {
 		ctx.StoreRoot = filepath.Dir(dir)
-		ctx.Operator = info.EnvironmentName
+		ctx.Operator = info.Name
 		return &ctx
 	}
 
@@ -102,9 +104,9 @@ func GetCwdCtx() *ContextConfig {
 		}
 		if ok {
 			ctx.StoreRoot = filepath.Dir(dir)
-			ctx.Operator = info.EnvironmentName
+			ctx.Operator = info.Name
 			sep := string(os.PathSeparator)
-			name := fmt.Sprintf("%s%s%s%s%s", sep, info.EnvironmentName, sep, store.Accounts, sep)
+			name := fmt.Sprintf("%s%s%s%s%s", sep, info.Name, sep, store.Accounts, sep)
 			idx := strings.Index(cwd, name)
 			if idx != -1 {
 				prefix := cwd[:idx+len(name)]
@@ -157,7 +159,7 @@ func isOperatorDir(dir string) (store.Info, bool, error) {
 		if err != nil {
 			return v, false, err
 		}
-		if v.EntityName != "" {
+		if v.Name != "" && v.Kind == jwt.OperatorClaim {
 			return v, true, nil
 		}
 	}

--- a/cmd/defaults_test.go
+++ b/cmd/defaults_test.go
@@ -79,7 +79,7 @@ func Test_isOperatorDir(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, ok)
 	require.NotEmpty(t, info)
-	require.Equal(t, "O", info.EntityName)
+	require.Equal(t, "O", info.Name)
 
 	info, ok, err = isOperatorDir(filepath.Dir(odir))
 	require.NoError(t, err)

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -25,10 +25,15 @@ import (
 )
 
 func envSet(varName string) string {
-	if os.Getenv(varName) == "" {
-		return "No"
+	return yn(os.Getenv(varName) != "")
+}
+
+func yn(v bool) string {
+	if v {
+		return "Yes"
 	}
-	return "Yes"
+	return "No"
+
 }
 
 func createEnvCmd() *cobra.Command {
@@ -92,6 +97,7 @@ func (p *SetContextParams) PrintEnv(cmd *cobra.Command) {
 	if r == "" {
 		r = "Not Set"
 	}
+	table.AddRow("From CWD", "", yn(GetCwdCtx() != nil))
 	table.AddRow("Stores Dir", "", AbbrevHomePaths(r))
 	table.AddRow("Default Operator", "", conf.Operator)
 	table.AddRow("Default Account", "", conf.Account)


### PR DESCRIPTION
modified tool to be cwd aware
- if the cwd is a directory that immediately has an operator under it, the stores dir is set to it
- if the cwd is a sub directory belonging to an operator, the stores dir is set to the operator's parent dir
- anywhere else, uses the set preference