### PR TITLE
added --overwrite-newer flag to prevent pull clobbers

### DIFF
--- a/cmd/listkeys.go
+++ b/cmd/listkeys.go
@@ -16,7 +16,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -180,9 +179,6 @@ func (p *ListKeysParams) SetDefaults(ctx ActionCtx) error {
 		account := p.account
 		if account == "" {
 			account = conf.Account
-		}
-		if account == "" {
-			return errors.New("set an account first or specify it with the --account flag")
 		}
 		p.operator = true
 		p.account = account

--- a/cmd/signerparams_test.go
+++ b/cmd/signerparams_test.go
@@ -129,7 +129,7 @@ func Test_SignerOperator(t *testing.T) {
 	require.FileExists(t, dest)
 
 	tests := CmdTests{
-		{createSignerCmd(nkeys.PrefixByteOperator, false, nil), []string{"sp"}, nil, nil, false},
+		{createSignerCmd(nkeys.PrefixByteOperator, false, nil), []string{"sp"}, nil, nil, true},
 		{createSignerCmd(nkeys.PrefixByteOperator, false, ts.OperatorKey), []string{"sp", "-K", dest}, nil, nil, false},
 	}
 
@@ -175,7 +175,7 @@ func Test_SignerParamsPathNotFound(t *testing.T) {
 	require.NoError(t, os.Remove(ts.OperatorKeyPath))
 	_, _, err := ExecuteCmd(createSignerCmd(nkeys.PrefixByteOperator, false, nil), "-K", ts.OperatorKeyPath)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "no such file or directory")
+	require.Contains(t, err.Error(), "unable to resolve any of the following signing keys in the keystore")
 }
 
 func Test_SignerParamsHomePath(t *testing.T) {


### PR DESCRIPTION
Added --overwrite-newer flag to prevent out-of-band modifications to a local jwt to not be clobbered by an user initiated pull.