### PR TITLE
describe entity as a "raw" jwt 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ compile:
 	goreleaser --snapshot --rm-dist --skip-validate --skip-publish --parallelism 12
 
 install: compile build
-	cp $(BUILD_DIR)/nsc_$(BUILD_OS)_$(BUILD_OS_ARCH)/* $(BUILD_OS_GOPATH)/bin
+	cp $(BUILD_DIR)/$(BUILD_OS)_$(BUILD_OS_ARCH)/* $(BUILD_OS_GOPATH)/bin
 
 cover: test
 	go tool cover -html=./coverage.out

--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var Raw bool
 var WideFlag bool
 var Wide = noopNameFilter
 
@@ -62,4 +63,5 @@ var describeCmd = &cobra.Command{
 func init() {
 	GetRootCmd().AddCommand(describeCmd)
 	describeCmd.PersistentFlags().BoolVarP(&WideFlag, "long-ids", "W", false, "display account ids on imports")
+	describeCmd.PersistentFlags().BoolVarP(&Raw, "raw", "R", false, "output the raw JWT (exclusive of long-ids)")
 }

--- a/cmd/describeaccount_test.go
+++ b/cmd/describeaccount_test.go
@@ -18,6 +18,8 @@ package cmd
 import (
 	"testing"
 
+	"github.com/nats-io/jwt"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,6 +40,27 @@ func TestDescribeAccount_Single(t *testing.T) {
 	require.Contains(t, stdout, opub)
 	// name for the account
 	require.Contains(t, stdout, " A ")
+}
+
+func TestDescribeAccountRaw(t *testing.T) {
+	ts := NewTestStore(t, "operator")
+	defer ts.Done(t)
+	oldRaw := Raw
+	Raw = true
+	defer func() {
+		Raw = oldRaw
+	}()
+
+	ts.AddAccount(t, "A")
+
+	stdout, _, err := ExecuteCmd(createDescribeAccountCmd())
+	require.NoError(t, err)
+
+	ac, err := jwt.DecodeAccountClaims(stdout)
+	require.NoError(t, err)
+
+	require.NotNil(t, ac)
+	require.Equal(t, "A", ac.Name)
 }
 
 func TestDescribeAccount_Multiple(t *testing.T) {

--- a/cmd/describeoperator_test.go
+++ b/cmd/describeoperator_test.go
@@ -18,6 +18,8 @@ package cmd
 import (
 	"testing"
 
+	"github.com/nats-io/jwt"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,6 +32,25 @@ func TestDescribeOperator_Single(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, stdout, pub)
 	require.Contains(t, stdout, " operator ")
+}
+
+func TestDescribeOperator_Raw(t *testing.T) {
+	ts := NewTestStore(t, "operator")
+	defer ts.Done(t)
+	oldRaw := Raw
+	Raw = true
+	defer func() {
+		Raw = oldRaw
+	}()
+
+	stdout, _, err := ExecuteCmd(createDescribeOperatorCmd())
+	require.NoError(t, err)
+
+	oc, err := jwt.DecodeOperatorClaims(stdout)
+	require.NoError(t, err)
+
+	require.NotNil(t, oc)
+	require.Equal(t, "operator", oc.Name)
 }
 
 func TestDescribeOperator_Multiple(t *testing.T) {

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -533,47 +533,71 @@ func (s *Store) LoadClaim(name ...string) (*jwt.GenericClaims, error) {
 }
 
 func (s *Store) ReadOperatorClaim() (*jwt.OperatorClaims, error) {
+	d, err := s.ReadRawOperatorClaim()
+	if err != nil {
+		return nil, err
+	}
+	c, err := jwt.DecodeOperatorClaims(string(d))
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (s *Store) ReadRawOperatorClaim() ([]byte, error) {
 	fn := JwtName(s.GetName())
 	if s.Has(fn) {
 		d, err := s.Read(fn)
 		if err != nil {
 			return nil, err
 		}
-		c, err := jwt.DecodeOperatorClaims(string(d))
-		if err != nil {
-			return nil, err
-		}
-		return c, nil
+		return d, nil
 	}
 	return nil, NewOperatorNotExistErr(s.GetName())
 }
 
 func (s *Store) ReadAccountClaim(name string) (*jwt.AccountClaims, error) {
+	d, err := s.ReadRawAccountClaim(name)
+	if err != nil {
+		return nil, err
+	}
+	c, err := jwt.DecodeAccountClaims(string(d))
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (s *Store) ReadRawAccountClaim(name string) ([]byte, error) {
 	if s.Has(Accounts, name, JwtName(name)) {
 		d, err := s.Read(Accounts, name, JwtName(name))
 		if err != nil {
 			return nil, err
 		}
-		c, err := jwt.DecodeAccountClaims(string(d))
-		if err != nil {
-			return nil, err
-		}
-		return c, nil
+		return d, nil
 	}
 	return nil, NewAccountNotExistErr(name)
 }
 
 func (s *Store) ReadUserClaim(accountName string, name string) (*jwt.UserClaims, error) {
+	d, err := s.ReadRawUserClaim(accountName, name)
+	if err != nil {
+		return nil, err
+	}
+	c, err := jwt.DecodeUserClaims(string(d))
+	if err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+func (s *Store) ReadRawUserClaim(accountName string, name string) ([]byte, error) {
 	if s.Has(Accounts, accountName, Users, JwtName(name)) {
 		d, err := s.Read(Accounts, accountName, Users, JwtName(name))
 		if err != nil {
 			return nil, err
 		}
-		c, err := jwt.DecodeUserClaims(string(d))
-		if err != nil {
-			return nil, err
-		}
-		return c, nil
+		return d, nil
 	}
 	return nil, NewUserNotExistErr(name)
 }


### PR DESCRIPTION
Added the ability to describe an operator, account or user in raw format. This allows the user to easily copy JWT formatted string for other purposes.