### PR TITLE
Disconnect/Close handlers print spurious messages on the tools depending on timing.

### DIFF
--- a/cmd/rtttool.go
+++ b/cmd/rtttool.go
@@ -101,13 +101,15 @@ func (p *RttParams) Run(ctx ActionCtx) (store.Status, error) {
 	opts := createDefaultToolOptions("nsc_rtt", ctx)
 	opts = append(opts, nats.UserCredentials(p.credsPath))
 	nc, err := nats.Connect(strings.Join(p.natsURLs, ", "), opts...)
+	defer nc.Close()
+
 	if err != nil {
 		return nil, err
 	}
-	defer nc.Close()
-
 	start := time.Now()
-	nc.Flush()
+	if err := nc.Flush(); err != nil {
+		return nil, err
+	}
 	rtt := time.Since(start)
 	ctx.CurrentCmd().Printf("round trip time to [%s] = %v\n", nc.ConnectedUrl(), rtt)
 	return nil, nil

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -44,12 +44,18 @@ func createDefaultToolOptions(name string, ctx ActionCtx) []nats.Option {
 		if err != nil {
 			ctx.CurrentCmd().Printf("Disconnected: error: %v\n", err)
 		}
+		if nc.Status() == nats.CLOSED {
+			return
+		}
 		ctx.CurrentCmd().Printf("Disconnected: will attempt reconnects for %.0fm", totalWait.Minutes())
 	}))
 	opts = append(opts, nats.ReconnectHandler(func(nc *nats.Conn) {
 		ctx.CurrentCmd().Printf("Reconnected [%s]", nc.ConnectedUrl())
 	}))
 	opts = append(opts, nats.ClosedHandler(func(nc *nats.Conn) {
+		if nc.Status() == nats.CLOSED {
+			return
+		}
 		ctx.CurrentCmd().Printf("Exiting, no servers available, or connection closed")
 	}))
 	return opts


### PR DESCRIPTION
The Go client behaves differently than the node client. So disconnect events are fired on close.
Changed disconnect/close handlers on the tools to check the status of the client, and thus avoid spurious disconnect/close messages.