### PR TITLE
Self-sign migrate

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -211,7 +211,7 @@ func (p *MigrateCmdParams) Validate(ctx ActionCtx) error {
 func (p *MigrateCmdParams) Run(ctx ActionCtx) (store.Status, error) {
 	ctx.CurrentCmd().SilenceUsage = true
 	p.operator = ctx.StoreCtx().Operator.Name
-	if p.isFileImport && ctx.StoreCtx().Store.IsManaged() {
+	if ctx.StoreCtx().Store.IsManaged() {
 		token, err := jwt.ParseDecoratedJWT([]byte(p.accountToken))
 		if err != nil {
 			return nil, err

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -18,13 +18,13 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/nats-io/nkeys"
 	"io/ioutil"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/nats-io/nkeys"
 	"github.com/nats-io/jwt"
 	"github.com/nats-io/nsc/cli"
 	"github.com/nats-io/nsc/cmd/store"


### PR DESCRIPTION
The migrate command needs to self-sign accounts before pushing to the remote server, or the account server will reject them.