### PR TITLE
FIX #180 - Allowed some commands (keys) to execute even if no store is set

### DIFF
--- a/cmd/exportkeys.go
+++ b/cmd/exportkeys.go
@@ -58,7 +58,7 @@ nsc export keys --account <name> (changes the account context to the specified a
 		Args:         MaxArgs(0),
 		SilenceUsage: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := RunAction(cmd, args, &params); err != nil {
+			if err := RunMaybeStorelessAction(cmd, args, &params); err != nil {
 				return err
 			}
 			return nil
@@ -108,6 +108,11 @@ func (p *ExportKeysParams) PostInteractive(ctx ActionCtx) error {
 }
 
 func (p *ExportKeysParams) Validate(ctx ActionCtx) error {
+	kdir := store.GetKeysDir()
+	_, err := os.Stat(kdir)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("keystore %q does not exist", kdir)
+	}
 	return nil
 }
 

--- a/cmd/exportkeys_test.go
+++ b/cmd/exportkeys_test.go
@@ -177,3 +177,13 @@ func Test_ExportRemove(t *testing.T) {
 	requireEmptyDir(t, filepath.Join(kr, "A"))
 	requireEmptyDir(t, filepath.Join(kr, "U"))
 }
+
+func Test_ExportNoKeyStore(t *testing.T) {
+	ts := NewEmptyStore(t)
+	defer ts.Done(t)
+
+	require.NoError(t, os.Remove(filepath.Join(ts.Dir, "keys")))
+	_, _, err := ExecuteCmd(createExportKeysCmd(), "--dir", ts.Dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
+}

--- a/cmd/generatenkey.go
+++ b/cmd/generatenkey.go
@@ -33,7 +33,7 @@ func createGenerateNKeyCmd() *cobra.Command {
 		Use:   "nkey",
 		Short: "Generates an nkey",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return RunAction(cmd, args, &params)
+			return RunMaybeStorelessAction(cmd, args, &params)
 		},
 	}
 	cmd.Flags().BoolVarP(&params.operator.generate, "operator", "o", false, "operator")

--- a/cmd/importkeys.go
+++ b/cmd/importkeys.go
@@ -38,7 +38,7 @@ nsc import keys --recursive --dir <path>
 		Args:         MaxArgs(0),
 		SilenceUsage: false,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := RunAction(cmd, args, &params); err != nil {
+			if err := RunMaybeStorelessAction(cmd, args, &params); err != nil {
 				return err
 			}
 			return nil

--- a/cmd/listkeys_test.go
+++ b/cmd/listkeys_test.go
@@ -17,6 +17,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -123,4 +125,14 @@ func Test_ListKeysFilter(t *testing.T) {
 	require.Contains(t, stderr, fmt.Sprintf("%s %s *", "O", opk))
 	require.NotContains(t, stderr, fmt.Sprintf("%s %s *", "A", ts.GetAccountPublicKey(t, "A")))
 	require.NotContains(t, stderr, fmt.Sprintf("%s %s *", "U", ts.GetUserPublicKey(t, "A", "U")))
+}
+
+func Test_ListKeysNoKeyStore(t *testing.T) {
+	ts := NewEmptyStore(t)
+	defer ts.Done(t)
+
+	require.NoError(t, os.Remove(filepath.Join(ts.Dir, "keys")))
+	_, _, err := ExecuteCmd(createListKeysCmd())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "does not exist")
 }

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -24,8 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/nats-io/nkeys"
 	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nsc/cli"
 	"github.com/nats-io/nsc/cmd/store"
 	"github.com/spf13/cobra"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ var cfgFile string
 //lint:ignore U1000 used by tests
 var ngsStore *store.Store
 var interceptorFn InterceptorFn
-var ErrNoOperator = errors.New("set an operator")
+var ErrNoOperator = errors.New("set an operator -- 'nsc env -o operatorName'")
 
 // show some other hidden commands if the env is set
 var show, _ = strconv.ParseBool(os.Getenv(TestEnv))


### PR DESCRIPTION
The action framework requires a store to be set. In some cases such as dealing with the keystore, it should be ok not to have it, the example is migrating from ngs. The store may not exist, but the keys do.