### PR TITLE
FIX #47  change add/edit/describe to allow extra argument as '--name'

### DIFF
--- a/cmd/addaccount.go
+++ b/cmd/addaccount.go
@@ -34,7 +34,7 @@ func CreateAddAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "account",
 		Short:        "Add an account",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -66,6 +66,10 @@ type AddAccountParams struct {
 }
 
 func (p *AddAccountParams) SetDefaults(ctx ActionCtx) error {
+	p.name = NameFlagOrArgument(p.name, ctx)
+	if p.name == "*" {
+		p.name = GetRandomName(0)
+	}
 	p.generate = p.keyPath == ""
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 	return nil

--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -148,3 +148,14 @@ func Test_AddAccountInteractiveSigningKey(t *testing.T) {
 	require.True(t, oc.DidSign(ac))
 	require.Equal(t, pk1, ac.Issuer)
 }
+
+func Test_AddAccountNameArg(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(HoistRootFlags(CreateAddAccountCmd()), "A")
+	require.NoError(t, err)
+
+	_, err = ts.Store.ReadAccountClaim("A")
+	require.NoError(t, err)
+}

--- a/cmd/addoperator.go
+++ b/cmd/addoperator.go
@@ -33,6 +33,7 @@ func createAddOperatorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "operator",
 		Short:        "Add an operator",
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -64,6 +65,7 @@ type AddOperatorParams struct {
 }
 
 func (p *AddOperatorParams) SetDefaults(ctx ActionCtx) error {
+	p.name = NameFlagOrArgument(p.name, ctx)
 	if p.name == "*" {
 		p.name = GetRandomName(0)
 	}

--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -224,3 +224,16 @@ func Test_AddNotWellKnownOperator(t *testing.T) {
 	_, _, err := ExecuteCmd(createAddOperatorCmd(), "--url", "X")
 	require.Error(t, err)
 }
+
+func Test_AddOperatorNameArg(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(HoistRootFlags(createAddOperatorCmd()), "X")
+	require.NoError(t, err)
+	ts.SwitchOperator(t, "X")
+
+	oc, err := ts.Store.ReadOperatorClaim()
+	require.NoError(t, err)
+	require.Equal(t, "X", oc.Name)
+}

--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -37,7 +37,7 @@ func CreateAddUserCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "user",
 		Short:        "Add an user to the account",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		Example:      params.longHelp(),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -102,6 +102,10 @@ toolName add user --name u --tag test,service_a`
 }
 
 func (p *AddUserParams) SetDefaults(ctx ActionCtx) error {
+	p.name = NameFlagOrArgument(p.name, ctx)
+	if p.name == "*" {
+		p.name = GetRandomName(0)
+	}
 	if err := p.AccountContextParams.SetDefaults(ctx); err != nil {
 		return err
 	}

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -202,3 +202,17 @@ func Test_AddUser_InteractiveResp(t *testing.T) {
 	require.Equal(t, 100, up.Resp.MaxMsgs)
 	require.Equal(t, time.Millisecond*1000, up.Resp.Expires)
 }
+
+func Test_AddUserNameArg(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	ts.AddAccount(t, "A")
+
+	_, _, err := ExecuteCmd(HoistRootFlags(CreateAddUserCmd()), "U")
+	require.NoError(t, err)
+
+	uc, err := ts.Store.ReadUserClaim("A", "U")
+	require.NoError(t, err)
+	require.Equal(t, "U", uc.Name)
+}

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -365,6 +365,17 @@ func AbbrevHomePaths(fp string) string {
 	return fp
 }
 
+func NameFlagOrArgument(name string, ctx ActionCtx) string {
+	return nameFlagOrArgument(name, ctx.Args())
+}
+
+func nameFlagOrArgument(name string, args []string) string {
+	if name == "" && len(args) > 0 {
+		return args[0]
+	}
+	return name
+}
+
 func MaxArgs(max int) cobra.PositionalArgs {
 	// if we are running in a test, remove the limit
 	if strings.Contains(strings.Join(os.Args, " "), "-test.v") {

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -457,3 +457,22 @@ func TestPushAccount(t *testing.T) {
 	require.Equal(t, apk, ac.Subject)
 	require.Equal(t, opk, ac.Issuer)
 }
+
+func Test_NameFlagArgOnlyOnEmpty(t *testing.T) {
+	var tests = []struct {
+		n   string
+		a   []string
+		out string
+	}{
+		{"", nil, ""},
+		{"a", nil, "a"},
+		{"a", []string{}, "a"},
+		{"a", []string{"b", "c"}, "a"},
+		{"", []string{"b", "c"}, "b"},
+	}
+
+	for i, v := range tests {
+		r := nameFlagOrArgument(v.n, v.a)
+		require.Equal(t, v.out, r, "failed test %d", i)
+	}
+}

--- a/cmd/describeaccount.go
+++ b/cmd/describeaccount.go
@@ -26,7 +26,7 @@ func createDescribeAccountCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "account",
 		Short:        "Describes an account",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunAction(cmd, args, &params)
@@ -50,6 +50,7 @@ type DescribeAccountParams struct {
 }
 
 func (p *DescribeAccountParams) SetDefaults(ctx ActionCtx) error {
+	p.AccountContextParams.Name = NameFlagOrArgument(p.AccountContextParams.Name, ctx)
 	p.AccountContextParams.SetDefaults(ctx)
 	return nil
 }

--- a/cmd/describeoperator.go
+++ b/cmd/describeoperator.go
@@ -29,7 +29,7 @@ func createDescribeOperatorCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "operator",
 		Short:        "Describes the operator",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunMaybeStorelessAction(cmd, args, &params)
@@ -53,6 +53,7 @@ type DescribeOperatorParams struct {
 }
 
 func (p *DescribeOperatorParams) SetDefaults(ctx ActionCtx) error {
+	p.name = NameFlagOrArgument(p.name, ctx)
 	if p.name != "" {
 		actx, ok := ctx.(*Actx)
 		if !ok {

--- a/cmd/describeuser.go
+++ b/cmd/describeuser.go
@@ -29,7 +29,7 @@ func createDescribeUserCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "user",
 		Short:        "Describes an user",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunAction(cmd, args, &params)
@@ -55,6 +55,7 @@ type DescribeUserParams struct {
 }
 
 func (p *DescribeUserParams) SetDefaults(ctx ActionCtx) error {
+	p.user = NameFlagOrArgument(p.user, ctx)
 	p.AccountContextParams.SetDefaults(ctx)
 	return nil
 }

--- a/cmd/describeuser_test.go
+++ b/cmd/describeuser_test.go
@@ -163,7 +163,7 @@ func TestDescribeUser_Account(t *testing.T) {
 
 	ts.AddAccount(t, "A")
 	_, pub, kp := CreateAccountKey(t)
-	_, _, err := ExecuteCmd(createEditAccount(), "--account", "A", "--sk", pub)
+	_, _, err := ExecuteCmd(createEditAccount(), "--name", "A", "--sk", pub)
 	require.NoError(t, err)
 
 	// signed with default account key
@@ -186,7 +186,7 @@ func TestDescribeRawUser(t *testing.T) {
 
 	ts.AddAccount(t, "A")
 	_, pub, kp := CreateAccountKey(t)
-	_, _, err := ExecuteCmd(createEditAccount(), "--account", "A", "--sk", pub)
+	_, _, err := ExecuteCmd(createEditAccount(), "--name", "A", "--sk", pub)
 	require.NoError(t, err)
 
 	// signed with default account key

--- a/cmd/editaccount.go
+++ b/cmd/editaccount.go
@@ -30,7 +30,7 @@ func createEditAccount() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "account",
 		Short:        "Edit an account",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunAction(cmd, args, &params)
@@ -48,7 +48,7 @@ func createEditAccount() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.exportsWc, "wildcard-exports", "", true, "exports can contain wildcards")
 	cmd.Flags().StringSliceVarP(&params.rmSigningKeys, "rm-sk", "", nil, "remove signing key - comma separated list or option can be specified multiple times")
 
-	params.AccountContextParams.BindFlags(cmd)
+	cmd.Flags().StringVarP(&params.AccountContextParams.Name, "name", "n", "", "account to edit")
 	params.signingKeys.BindFlags("sk", "", nkeys.PrefixByteAccount, cmd)
 	params.TimeParams.BindFlags(cmd)
 
@@ -78,6 +78,7 @@ type EditAccountParams struct {
 }
 
 func (p *EditAccountParams) SetDefaults(ctx ActionCtx) error {
+	p.AccountContextParams.Name = NameFlagOrArgument(p.AccountContextParams.Name, ctx)
 	if err := p.AccountContextParams.SetDefaults(ctx); err != nil {
 		return err
 	}

--- a/cmd/editaccount_test.go
+++ b/cmd/editaccount_test.go
@@ -32,7 +32,7 @@ func Test_EditAccount(t *testing.T) {
 
 	tests := CmdTests{
 		{createEditAccount(), []string{"edit", "account"}, nil, []string{"specify an edit option"}, true},
-		{createEditAccount(), []string{"edit", "account", "--tag", "A", "--account", "A"}, nil, []string{"edited account \"A\""}, false},
+		{createEditAccount(), []string{"edit", "account", "--tag", "A", "--name", "A"}, nil, []string{"edited account \"A\""}, false},
 	}
 
 	tests.Run(t, "root", "edit")

--- a/cmd/editoperator.go
+++ b/cmd/editoperator.go
@@ -30,7 +30,7 @@ func createEditOperatorCmd() *cobra.Command {
 	var params EditOperatorParams
 	cmd := &cobra.Command{
 		Use:          "operator",
-		Short:        "Edit an operator",
+		Short:        "Edit the operator",
 		Args:         MaxArgs(0),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/edituser.go
+++ b/cmd/edituser.go
@@ -35,7 +35,7 @@ func createEditUserCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "user",
 		Short:        "Edit an user",
-		Args:         MaxArgs(0),
+		Args:         cobra.MaximumNArgs(1),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return RunAction(cmd, args, &params)
@@ -66,8 +66,6 @@ func createEditUserCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&params.name, "name", "n", "", "user name")
 
-	cmd.Flags().StringVarP(&params.out, "output-file", "o", "", "output file '--' is stdout")
-
 	params.AccountContextParams.BindFlags(cmd)
 	params.GenericClaimsParams.BindFlags(cmd)
 
@@ -85,7 +83,6 @@ type EditUserParams struct {
 	claim         *jwt.UserClaims
 	name          string
 	token         string
-	out           string
 	credsFilePath string
 
 	allowPubs   []string
@@ -104,6 +101,7 @@ type EditUserParams struct {
 }
 
 func (p *EditUserParams) SetDefaults(ctx ActionCtx) error {
+	p.name = NameFlagOrArgument(p.name, ctx)
 	p.AccountContextParams.SetDefaults(ctx)
 	p.SignerParams.SetDefaults(nkeys.PrefixByteAccount, true, ctx)
 

--- a/cmd/edituser_test.go
+++ b/cmd/edituser_test.go
@@ -205,7 +205,7 @@ func Test_EditUserSK(t *testing.T) {
 
 	s, p, _ := CreateAccountKey(t)
 	ts.AddAccount(t, "A")
-	_, _, err := ExecuteCmd(HoistRootFlags(createEditAccount()), "-a", "A", "--sk", p)
+	_, _, err := ExecuteCmd(HoistRootFlags(createEditAccount()), "--name", "A", "--sk", p)
 	require.NoError(t, err)
 
 	ac, err := ts.Store.ReadAccountClaim("A")
@@ -232,7 +232,7 @@ func Test_EditUserAddedWithSK(t *testing.T) {
 
 	s, p, sk := CreateAccountKey(t)
 	ts.AddAccount(t, "A")
-	_, _, err := ExecuteCmd(HoistRootFlags(createEditAccount()), "-a", "A", "--sk", p)
+	_, _, err := ExecuteCmd(HoistRootFlags(createEditAccount()), "--name", "A", "--sk", p)
 	require.NoError(t, err)
 
 	ac, err := ts.Store.ReadAccountClaim("A")


### PR DESCRIPTION
changed commands that add/edit/describe to accept an extra argument as the '--name' argument.
This makes it possible to `nsc add account A` which is more natural if a bit ambiguous.