### PR TITLE
Collapsing status hid server messages. Now if a child status contains

### DIFF
--- a/cmd/store/status.go
+++ b/cmd/store/status.go
@@ -199,8 +199,7 @@ func (r *Report) printsDetails() bool {
 
 func (r *Report) HasServerMessages() bool {
 	for _, v := range r.Details {
-		_, ok := v.(*ServerMessage)
-		if ok {
+		if _, ok := v.(*ServerMessage); ok {
 			return true
 		}
 	}

--- a/cmd/store/status.go
+++ b/cmd/store/status.go
@@ -192,7 +192,17 @@ func (r *Report) printsDetails() bool {
 	case DetailsOnly:
 		return true
 	case DetailsOnErrorOrWarning:
-		return r.StatusCode != OK
+		return r.StatusCode != OK || r.HasServerMessages()
+	}
+	return false
+}
+
+func (r *Report) HasServerMessages() bool {
+	for _, v := range r.Details {
+		_, ok := v.(*ServerMessage)
+		if ok {
+			return true
+		}
 	}
 	return false
 }

--- a/cmd/store/status_test.go
+++ b/cmd/store/status_test.go
@@ -161,3 +161,22 @@ func Test_Nested(t *testing.T) {
 	require.Contains(t, lines[3], fmt.Sprintf(warnTemplate, "something not so great"))
 	require.Contains(t, lines[4], fmt.Sprintf(errTemplate, "some error"))
 }
+
+func Test_ServerMessagesAllwaysShow(t *testing.T) {
+	s := NewReport(OK, "summary")
+	s.Opt = DetailsOnErrorOrWarning
+	s.AddOK("one")
+
+	m := s.Message()
+	lines := strings.Split(m, "\n")
+	require.Len(t, lines, 1)
+	require.Contains(t, lines[0], "summary")
+
+	s.Add(NewServerMessage("server says"))
+	m = s.Message()
+	lines = strings.Split(m, "\n")
+	require.Len(t, lines, 3)
+	require.Contains(t, lines[0], "summary")
+	require.Contains(t, lines[1], "one")
+	require.Contains(t, lines[2], "server says")
+}


### PR DESCRIPTION
server messages, those messages are shown.