### PR TITLE
fix stream imports to allow empty prefixes for streams

### DIFF
--- a/cmd/describer.go
+++ b/cmd/describer.go
@@ -180,7 +180,7 @@ func NewImportsDescriber(imports jwt.Imports) *ImportsDescriber {
 func (i *ImportsDescriber) Describe() string {
 	table := tablewriter.CreateTable()
 	table.AddTitle("Imports")
-	table.AddHeaders("Name", "Type", "Remote", "Local", "Expires", "From Account", "Public")
+	table.AddHeaders("Name", "Type", "Remote", "Local/Prefix", "Expires", "From Account", "Public")
 
 	for _, v := range i.Imports {
 		NewImportDescriber(*v).Brief(table)


### PR DESCRIPTION
FIX #203 - stream imports can have empty prefixes
Fixed imports from local accounts to correctly handle public services
Fixed import table header say "Local/Prefix" on import describers