### PR TITLE
changes to normalize and make it easier to select imports/exports when deleting them

### DIFF
--- a/cmd/addexport_test.go
+++ b/cmd/addexport_test.go
@@ -65,27 +65,31 @@ func validateAddExports(t *testing.T, ts *TestStore) {
 	require.NoError(t, err)
 
 	require.Len(t, ac.Exports, 4)
+	m := make(map[string]*jwt.Export)
+	for _, v := range ac.Exports {
+		m[v.Name] = v
+	}
 
-	pubfoo := ac.Exports[0]
-	require.Equal(t, "pubfoo", pubfoo.Name)
+	pubfoo := m["pubfoo"]
+	require.NotNil(t, pubfoo)
 	require.Equal(t, "pubfoo", string(pubfoo.Subject))
 	require.Equal(t, jwt.Stream, pubfoo.Type)
 	require.False(t, pubfoo.TokenReq)
 
-	privfoo := ac.Exports[1]
-	require.Equal(t, "privfoo", privfoo.Name)
+	privfoo := m["privfoo"]
+	require.NotNil(t, privfoo)
 	require.Equal(t, "privfoo", string(privfoo.Subject))
 	require.Equal(t, jwt.Stream, privfoo.Type)
 	require.True(t, privfoo.TokenReq)
 
-	pubbar := ac.Exports[2]
-	require.Equal(t, "pubbar", pubbar.Name)
+	pubbar := m["pubbar"]
+	require.NotNil(t, pubbar)
 	require.Equal(t, "pubbar", string(pubbar.Subject))
 	require.Equal(t, jwt.Service, pubbar.Type)
 	require.False(t, pubbar.TokenReq)
 
-	privbar := ac.Exports[3]
-	require.Equal(t, "privbar", privbar.Name)
+	privbar := m["privbar"]
+	require.NotNil(t, privbar)
 	require.Equal(t, "privbar", string(privbar.Subject))
 	require.Equal(t, jwt.Service, privbar.Type)
 	require.True(t, privbar.TokenReq)

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2019 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -72,19 +72,19 @@ func (c *CmdTest) RunTest(t *testing.T, chain []string, index int) {
 	stdout, stderr, err := ExecuteCmd(root, c.args...)
 	for _, v := range c.hasOutput {
 		if !strings.Contains(stdout, v) {
-			t.Fatalf("%d command '%v' stdout doesn't have %q\nstdout:\n%s\nstderr:\n%s\n", index, c, v, stdout, stderr)
+			t.Fatalf("test %d command '%v' stdout doesn't have %q\nstdout:\n%s\nstderr:\n%s\n", index, c, v, stdout, stderr)
 		}
 	}
 	for _, v := range c.hasError {
 		if !strings.Contains(stderr, v) {
-			t.Fatalf("%d command '%v' stderr doesn't have %q\nstdout:\n%s\nstderr:\n%s\n", index, c, v, stdout, stderr)
+			t.Fatalf("test %d command '%v' stderr doesn't have %q\nstdout:\n%s\nstderr:\n%s\n", index, c, v, stdout, stderr)
 		}
 	}
 	if c.shouldFail && err == nil {
-		t.Fatalf("%d command '%v' should have failed but didn't\nstdout:\n%s\nstderr:\n%s\n", index, c, stdout, stderr)
+		t.Fatalf("test %d command '%v' should have failed but didn't\nstdout:\n%s\nstderr:\n%s\n", index, c, stdout, stderr)
 	}
 	if !c.shouldFail && err != nil {
-		t.Fatalf("%d command '%v' should have not failed: %v", index, c, err)
+		t.Fatalf("test %d command '%v' should have not failed: %v", index, c, err)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/mitchellh/go-homedir v1.0.0
 	github.com/mitchellh/go-wordwrap v1.0.0
 	github.com/mitchellh/mapstructure v1.1.2 // indirect
-	github.com/nats-io/jwt v0.2.17-0.20190918212138-3cf585455e54
+	github.com/nats-io/jwt v0.3.1-0.20190920180816-3289d6f980ad
 	github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329
 	github.com/nats-io/nats.go v1.8.1
 	github.com/nats-io/nkeys v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQz
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/nats-io/jwt v0.2.6 h1:eAyoYvGgGLXR2EpnsBUvi/FcFrBqN6YKFVbOoEfPN4k=
 github.com/nats-io/jwt v0.2.6/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrWvvY=
-github.com/nats-io/jwt v0.2.17-0.20190918212138-3cf585455e54 h1:lQW+tbi7m4ippz6kcWmKinHRz4U8eaZrV82Nc0EdC6s=
-github.com/nats-io/jwt v0.2.17-0.20190918212138-3cf585455e54/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
+github.com/nats-io/jwt v0.3.1-0.20190920180816-3289d6f980ad h1:3JS/Fxo8s+wfFdaYeIMPgIYDq2WsgTvjFEjXAUoUXtI=
+github.com/nats-io/jwt v0.3.1-0.20190920180816-3289d6f980ad/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329 h1:RjMdWlS/avIVeXLjWxrHmxoiNPcvLXVWqpO7Bp6hyTk=
 github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329/go.mod h1:RyVdsHHvY4B6c9pWG+uRLpZ0h0XsqiuKp2XCTurP5LI=
 github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ=

--- a/vendor/github.com/nats-io/jwt/account_claims.go
+++ b/vendor/github.com/nats-io/jwt/account_claims.go
@@ -17,6 +17,7 @@ package jwt
 
 import (
 	"errors"
+	"sort"
 	"time"
 
 	"github.com/nats-io/nkeys"
@@ -127,7 +128,8 @@ func (a *AccountClaims) Encode(pair nkeys.KeyPair) (string, error) {
 	if !nkeys.IsValidPublicAccountKey(a.Subject) {
 		return "", errors.New("expected subject to be account public key")
 	}
-
+	sort.Sort(a.Exports)
+	sort.Sort(a.Imports)
 	a.ClaimsData.Type = AccountClaim
 	return a.ClaimsData.Encode(pair, a)
 }

--- a/vendor/github.com/nats-io/jwt/creds_utils.go
+++ b/vendor/github.com/nats-io/jwt/creds_utils.go
@@ -132,8 +132,6 @@ func FormatUserConfig(jwtString string, seed []byte) ([]byte, error) {
 
 // ParseDecoratedJWT takes a creds file and returns the JWT portion.
 func ParseDecoratedJWT(contents []byte) (string, error) {
-	defer wipeSlice(contents)
-
 	items := userConfigRE.FindAllSubmatch(contents, -1)
 	if len(items) == 0 {
 		return string(contents), nil
@@ -150,7 +148,6 @@ func ParseDecoratedJWT(contents []byte) (string, error) {
 // key pair from it.
 func ParseDecoratedNKey(contents []byte) (nkeys.KeyPair, error) {
 	var seed []byte
-	defer wipeSlice(contents)
 
 	items := userConfigRE.FindAllSubmatch(contents, -1)
 	if len(items) > 1 {
@@ -200,11 +197,4 @@ func ParseDecoratedUserNKey(contents []byte) (nkeys.KeyPair, error) {
 		return nil, err
 	}
 	return kp, nil
-}
-
-// Just wipe slice with 'x', for clearing contents of nkey seed file.
-func wipeSlice(buf []byte) {
-	for i := range buf {
-		buf[i] = 'x'
-	}
 }

--- a/vendor/github.com/nats-io/jwt/exports.go
+++ b/vendor/github.com/nats-io/jwt/exports.go
@@ -158,7 +158,7 @@ func (e *Export) IsRevoked(pubKey string) bool {
 	return e.Revocations.IsRevoked(pubKey, time.Now())
 }
 
-// Exports is an array of exports
+// Exports is a slice of exports
 type Exports []*Export
 
 // Add appends exports to the list
@@ -221,4 +221,16 @@ func (e *Exports) HasExportContainingSubject(subject Subject) bool {
 		}
 	}
 	return false
+}
+
+func (e Exports) Len() int {
+	return len(e)
+}
+
+func (e Exports) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+
+func (e Exports) Less(i, j int) bool {
+	return e[i].Subject < e[j].Subject
 }

--- a/vendor/github.com/nats-io/jwt/header.go
+++ b/vendor/github.com/nats-io/jwt/header.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// Version is semantic version.
-	Version = "0.2.18"
+	Version = "0.3.0"
 
 	// TokenTypeJwt is the JWT token type supported JWT tokens
 	// encoded and decoded by this library

--- a/vendor/github.com/nats-io/jwt/imports.go
+++ b/vendor/github.com/nats-io/jwt/imports.go
@@ -120,7 +120,14 @@ type Imports []*Import
 
 // Validate checks if an import is valid for the wrapping account
 func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
+	toSet := make(map[Subject]bool, len(*i))
 	for _, v := range *i {
+		if v.Type == Service {
+			if _, ok := toSet[v.To]; ok {
+				vr.AddError("Duplicate To subjects for %q", v.To)
+			}
+			toSet[v.To] = true
+		}
 		v.Validate(acctPubKey, vr)
 	}
 }
@@ -128,4 +135,16 @@ func (i *Imports) Validate(acctPubKey string, vr *ValidationResults) {
 // Add is a simple way to add imports
 func (i *Imports) Add(a ...*Import) {
 	*i = append(*i, a...)
+}
+
+func (i Imports) Len() int {
+	return len(i)
+}
+
+func (i Imports) Swap(j, k int) {
+	i[j], i[k] = i[k], i[j]
+}
+
+func (i Imports) Less(j, k int) bool {
+	return i[j].Subject < i[k].Subject
 }

--- a/vendor/github.com/nats-io/jwt/operator_claims.go
+++ b/vendor/github.com/nats-io/jwt/operator_claims.go
@@ -26,9 +26,19 @@ import (
 
 // Operator specific claims
 type Operator struct {
-	Identities          []Identity `json:"identity,omitempty"`
-	SigningKeys         StringList `json:"signing_keys,omitempty"`
-	AccountServerURL    string     `json:"account_server_url,omitempty"`
+	// Slice of real identies (like websites) that can be used to identify the operator.
+	Identities []Identity `json:"identity,omitempty"`
+	// Slice of other operator NKeys that can be used to sign on behalf of the main
+	// operator identity.
+	SigningKeys StringList `json:"signing_keys,omitempty"`
+	// AccountServerURL is a partial URL like "https://host.domain.org:<port>/jwt/v1"
+	// tools will use the prefix and build queries by appending /accounts/<account_id>
+	// or /operator to the path provided. Note this assumes that the account server
+	// can handle requests in a nats-account-server compatible way. See
+	// https://github.com/nats-io/nats-account-server.
+	AccountServerURL string `json:"account_server_url,omitempty"`
+	// A list of NATS urls (tls://host:port) where tools can connect to the server
+	// using proper credentials.
 	OperatorServiceURLs StringList `json:"operator_service_urls,omitempty"`
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/mitchellh/go-homedir
 github.com/mitchellh/go-wordwrap
 # github.com/mitchellh/mapstructure v1.1.2
 github.com/mitchellh/mapstructure
-# github.com/nats-io/jwt v0.2.17-0.20190918212138-3cf585455e54
+# github.com/nats-io/jwt v0.3.1-0.20190920180816-3289d6f980ad
 github.com/nats-io/jwt
 # github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329
 github.com/nats-io/nats-server/v2/server


### PR DESCRIPTION
- on interactive streams are rendered with `-> subject` and services with `<- subject`
- add import flag `--local-subject` changed description as 'local subject or prefix'
- stream imports no longer force a prefix
- removed `--service` flag from delete import - the unique identifier is the remote subject
- for non interactive imports delete, if the subject has multiple matches, `--src-account` with account key is required