### PR TITLE
Push activations to account server

### DIFF
--- a/cmd/addimport.go
+++ b/cmd/addimport.go
@@ -230,7 +230,6 @@ func (p *AddImportParams) generateToken(ctx ActionCtx, c *AccountExportChoice) e
 	var ap GenerateActivationParams
 	ap.Name = c.Name
 	ap.claims = srcAC
-	ap.service = c.Selection.IsService()
 	ap.accountKey.publicKey = ctx.StoreCtx().Account.PublicKey
 	ap.export = *c.Selection
 	ap.subject = p.remote
@@ -249,7 +248,7 @@ func (p *AddImportParams) generateToken(ctx ActionCtx, c *AccountExportChoice) e
 		return err
 	}
 
-	p.token = []byte(ap.Token)
+	p.token = []byte(ap.Token())
 	return p.initFromActivation(ctx)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,3 +40,5 @@ require (
 	gopkg.in/AlecAivazis/survey.v1 v1.7.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
+
+go 1.13


### PR DESCRIPTION
FIX #215 - export selection is single list
FIX #211 - added `--push` to push the activation to the account server