### PR TITLE
Disable CGO

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ release:
 builds:
 - main: ./main.go
   ldflags: "-X main.version={{.Tag}}"
+  env:
+    - CGO_ENABLED=0
   binary: nsc
   goos:
   - darwin


### PR DESCRIPTION
This change disables CGO and makes the binary fully static. The motivation for this is to make it easier to install nsc in Alpine containers.

I tested this change locally with these commands.

```
CGO_ENABLED=0 go install
ldd $(which nsc)
nsc init
nsc list operators
```

Everything seems to work. The menus had color, I was able to select options with up/down arrows, and the lists have borders around them.

I ran those commands on Arch and Alpine. Not sure if macOS would have problems.