### PR TITLE
Update NSC init message

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -414,9 +414,9 @@ func (p *InitCmdParams) Run(ctx ActionCtx) (store.Status, error) {
 
 	if p.CreateOperator {
 		local := `to run a local server using this configuration, enter:
-cmd.Printf("> nsc generate config --mem-resolver --config-file <path/server.conf>
-cmd.Printf("start a nats-server using the generated config:
-cmd.Printf("> nats-server -c <path/server.conf>`
+  nsc generate config --mem-resolver --config-file <path/server.conf>
+then start a nats-server using the generated config:
+  nats-server -c <path/server.conf>`
 		r.Add(store.NewServerMessage(local))
 	}
 	if len(p.ServiceURLs) > 0 {


### PR DESCRIPTION
There are a few cmd Printf messages that look wrong...

```sh
nsc init -d /nsc
[ OK ] created operator gracious_stallman
[ OK ] created account gracious_stallman
[ OK ] created user "gracious_stallman"
[ OK ] project jwt files created in "/nsc"
[ OK ] user creds file stored in "/nsc/nkeys/creds/gracious_stallman/gracious_stallman/gracious_stallman.creds"
> to run a local server using this configuration, enter:
> cmd.Printf("> nsc generate config --mem-resolver --config-file <path/server.conf>
> cmd.Printf("start a nats-server using the generated config:
> cmd.Printf("> nats-server -c <path/server.conf>
all jobs succeeded
```

With the changes it looks like this now:

```sh
[ OK ] created operator heuristic_gates
[ OK ] created account heuristic_gates
[ OK ] created user "heuristic_gates"
[ OK ] project jwt files created in "~/repos/nats-dev/src/github.com/nats-io/nsc/some-other-folder-4"
[ OK ] user creds file stored in "~/.nkeys/creds/heuristic_gates/heuristic_gates/heuristic_gates.creds"
> to run a local server using this configuration, enter:
>   nsc generate config --mem-resolver --config-file <path/server.conf>
> then start a nats-server using the generated config:
>   nats-server -c <path/server.conf>
all jobs succeeded
```