### PR TITLE
Add a portable shell install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,16 @@ A tool for creating NATS account and user access configurations
 
 With Python:
 
-```python
+```bash
 curl -L https://raw.githubusercontent.com/nats-io/nsc/master/install.py | python
+```
+
+Without Python and with a more cautious mindset:
+
+```bash
+curl -LO https://raw.githubusercontent.com/nats-io/nsc/master/install.sh
+less install.sh
+sh ./install.sh
 ```
 
 With Homebrew:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,292 @@
+#!/bin/sh
+set -eu
+
+# Copyright 2020 The NATS Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# We are sh, not bash; we might want bash/zsh for associative arrays but some
+# OSes are currently on bash3 and removing bash, while we don't want a zsh
+# dependency; so we're sticking to "pretty portable shell" even if it's a
+# little more convoluted as a result.
+#
+# We rely upon the following beyond basic POSIX shell:
+#  1. A  `local`  command (built-in to shell; almost all sh does have this)
+#  2. A  `curl`   command (to download files)
+#  3. An `unzip`  command (to extract content from .zip files)
+#  4. A  `mktemp` command (to stage a downloaded zip-file)
+
+# We rely upon naming conventions for release assets from GitHub to avoid
+# having to parse JSON from their API, to avoid a dependency upon jq(1).
+#
+# <https://help.github.com/en/github/administering-a-repository/linking-to-releases>
+# guarantees that:
+#    /<owner>/<name>/releases/latest/download/<asset-name>.zip
+# will be available; going via the API we got, for 'latest':
+#    https://github.com/nats-io/nsc/releases/download/0.4.0/nsc-linux-amd64.zip
+# ie:
+#    /<owner>/<name>/releases/download/<release>/<asset-name>.zip
+# Inspecting headers, the documented guarantee redirects to the API-returned
+# URL, which redirects to the S3 bucket download URL.
+
+# Like the Python before us, we only support amd64 for now, and that's all that
+# nsc releases.  By calling this out up top, it should make it easier to find
+# the places which matter should that change in the future.
+readonly RELEASE_ARCH="amd64"
+
+# Finding the releases to download
+readonly GITHUB_OWNER_REPO='nats-io/nsc'
+readonly HTTP_USER_AGENT='nsc_install/0.1 (@nats-io)'
+
+# Where to install to, relative to home-dir
+readonly NSC_RELATIVE_BIN_DIR='.nsccli/bin'
+# Binary name we are looking for (might have .exe extension on some platforms)
+readonly NSC_BINARY_BASENAME='nsc'
+
+progname="$(basename "$0" .sh)"
+note() { printf >&2 '%s: %s\n' "$progname" "$*"; }
+die() { note "$@"; exit 1; }
+
+main() {
+  parse_options "$@"
+  shift $((OPTIND - 1))
+  # error early if missing commands; put it after option processing
+  # so that if we need to, we can add options to handle alternatives.
+  check_have_external_commands
+
+  # mkdir -m does not set permissions of parents; -v is not portable
+  # We don't create anything private, so stick to inherited umask.
+  mkdir -p -- "$opt_install_dir"
+
+  zipfile_url="$(determine_zip_download_url)"
+  [ -n "${zipfile_url}" ] || die "unable to determine a download URL"
+  want_filename="$(exe_filename_per_os)"
+
+  # The unzip command does not work well with piped stdin, we need to have
+  # the complete zip-file on local disk.  The portability of mktemp(1) is
+  # an unpleasant situation.
+  # This is the sanest way to get a temporary directory which only we can
+  # even look inside.
+  old_umask="$(umask)"
+  umask 077
+  zip_dir="$(mktemp -d 2>/dev/null || mktemp -d -t 'ziptmpdir')" || \
+    die "failed to create a temporary directory with mktemp(1)"
+  umask "$old_umask"
+  # POSIX does not give rm(1) a `-v` flag.
+  trap "rm -rf -- '${zip_dir}'" EXIT
+
+  stage_zipfile="${zip_dir}/$(zip_filename_per_os)"
+
+  note "Downloading <${zipfile_url}>"
+  curl_cmd --progress-bar --location --output "$stage_zipfile" "$zipfile_url"
+
+  note "Extracting ${want_filename} from $stage_zipfile"
+  # But unzip(1) does not let us override permissions and it does not obey
+  # umask so the file might now exist with overly broad permissions, depending
+  # upon whether or not the local environment has a per-user group which was
+  # used.  We don't know that the extracting user wants everyone else in their
+  # current group to be able to write to the file.
+  # So: extract into the temporary directory, which we've forced via umask to
+  # be self-only, chmod while it's safe in there, and then move it into place.
+  #   -b is not in busybox, so we rely on unzip handling binary safely
+  #   -j junks paths inside the zipfile; none expected, enforce that
+  unzip -j -d "$zip_dir" "$stage_zipfile" "$want_filename"
+  chmod 0755 "$zip_dir/$want_filename"
+  # prompt the user to overwrite if need be
+  mv -i -- "$zip_dir/$want_filename" "$opt_install_dir/./"
+
+  link_and_show_instructions "$want_filename"
+}
+
+usage() {
+  local ev="${1:-1}"
+  [ "$ev" = 0 ] || exec >&2
+  cat <<EOUSAGE
+Usage: $progname [-t <tag>] [-d <dir>] [-s <dir>]
+ -d dir     directory to download into [default: ~/$NSC_RELATIVE_BIN_DIR]
+ -s dir     directory in which to place a symlink to the binary
+            [default: ~/bin] [use '-' to forcibly not place a symlink]
+ -t tag     retrieve a tagged release instead of the latest
+EOUSAGE
+  exit "$ev"
+}
+
+opt_tag=''
+opt_install_dir=''
+opt_symlink_dir=''
+parse_options() {
+  while getopts ':d:hs:t:' arg; do
+    case "$arg" in
+      (h) usage 0 ;;
+
+      (d) opt_install_dir="$OPTARG" ;;
+      (s) opt_symlink_dir="$OPTARG" ;;
+      (t) opt_tag="$OPTARG" ;;
+
+      (:) die "missing required option for -$OPTARG; see -h for help" ;;
+      (\?) die "unknown option -$OPTARG; see -h for help" ;;
+      (*) die "unhandled option -$arg; CODE BUG" ;;
+    esac
+  done
+
+  if [ "$opt_install_dir" = "" ]; then
+    opt_install_dir="${HOME:?}/${NSC_RELATIVE_BIN_DIR}"
+  fi
+  if [ "$opt_symlink_dir" = "" ] && [ -d "$HOME/bin" ]; then
+    opt_symlink_dir="$HOME/bin"
+  elif [ "$opt_symlink_dir" = "-" ]; then
+    opt_symlink_dir=""
+  fi
+}
+
+check_have_external_commands() {
+  local cmd
+
+  # Only those commands which take --help :
+  for cmd in curl unzip
+  do
+    "$cmd" --help >/dev/null || die "missing command: $cmd"
+  done
+
+  # Our invocation of mktemp has to handle multiple variants; if that's not
+  # installed, let it fail later.
+
+  test -e /dev/stdin || die "missing device /dev/stdin"
+}
+
+normalized_ostype() {
+  local ostype
+  # We only need to worry about ASCII here
+  ostype="$(uname -s | tr A-Z a-z)"
+  case "$ostype" in
+    (*linux*)  ostype="linux" ;;
+    (win32)    ostype="windows" ;;
+    (ming*_nt) ostype="windows" ;;
+  esac
+  printf '%s\n' "$ostype"
+}
+
+zip_filename_per_os() {
+  printf '%s\n' "nsc-$(normalized_ostype)-${RELEASE_ARCH}.zip"
+}
+
+exe_filename_per_os() {
+  local fn="$NSC_BINARY_BASENAME"
+  case "$(normalized_ostype)" in
+    (windows) fn="${fn}.exe" ;;
+  esac
+  printf '%s\n' "$fn"
+}
+
+curl_cmd() {
+  curl --user-agent "$HTTP_USER_AGENT" "$@"
+}
+
+determine_zip_download_url() {
+  local want_filename download_url
+
+  want_filename="$(zip_filename_per_os)"
+  if [ -n "$opt_tag" ]; then
+    printf 'https://github.com/%s/releases/download/%s/%s\n' \
+      "$GITHUB_OWNER_REPO" "$opt_tag" "$want_filename"
+  else
+    printf 'https://github.com/%s/releases/latest/download/%s\n' \
+      "$GITHUB_OWNER_REPO" "$want_filename"
+  fi
+}
+
+dir_is_in_PATH() {
+  local needle="$1"
+  local oIFS="$IFS"
+  local pathdir
+  case "$(normalized_ostype)" in
+    (windows) IFS=';' ;;
+    (*)       IFS=':' ;;
+  esac
+  set $PATH
+  IFS="$oIFS"
+  for pathdir
+  do
+    if [ "$pathdir" = "$needle" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# Returns true if no further installation instructions are needed;
+# Returns false otherwise.
+maybe_make_symlink() {
+  local target="${1:?need a file to link to}"
+  local symdir="${2:?need a directory within which to create a symlink}"
+  local linkname="${3:?need a name to give the symlink}"
+
+  if ! [ -d "$symdir" ]; then
+    note "skipping symlink because directory does not exist: $symdir"
+    return 1
+  fi
+  # ln(1) `-v` is busybox but is not POSIX
+  if ! ln -sf -- "$target" "$symdir/$linkname"
+  then
+    note "failed to create a symlink in: $symdir"
+    return 1
+  fi
+  ls -ld -- "$symdir/$linkname"
+  if dir_is_in_PATH "$symdir"; then
+    note "Symlink dir '$symdir' is already in your PATH"
+    return 0
+  fi
+  note "Symlink dir '$symdir' is not in your PATH?"
+  return 1
+}
+
+link_and_show_instructions() {
+  local new_cmd="${1:?need a command which has been installed}"
+
+  local target="$opt_install_dir/$new_cmd"
+
+  echo
+  note "NSC: $target"
+  ls -ld -- "$target"
+
+  if [ -n "$opt_symlink_dir" ]; then
+    if maybe_make_symlink "$target" "$opt_symlink_dir" "$new_cmd"
+    then
+      return 0
+    fi
+  fi
+
+  echo
+  printf 'Now manually add %s to your $PATH\n' "$opt_install_dir"
+
+  case "$(normalized_ostype)" in
+    (windows) cat <<EOWINDOWS ;;
+Windows Cmd Prompt Example:
+  setx path %path;"${opt_install_dir}"
+
+EOWINDOWS
+
+    (*) cat <<EOOTHER ;;
+Bash Example:
+  echo 'export PATH="\${PATH}:${opt_install_dir}"' >> ~/.bashrc
+  source ~/.bashrc
+
+Zsh Example:
+  echo 'path+=("${opt_install_dir}")' >> ~/.zshrc
+  source ~/.zshrc
+
+EOOTHER
+
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
This is not quite POSIX shell, we do ask for `local` to be available, and a few basic commands.  It's about as portable as I can make it without twisting into deep knots which risk adding bugs.

External commands required beyond POSIX: curl unzip mktemp

Document the usage of this script.

Adjust the Python to also use ~/.bashrc not ~/.bash_profile because the profile won't be run in all situations while the rc file should be used whenever the user has an interactive bash shell.

Usage for the shell differs slightly from the Python; it has a `-h` help option:

    % ./install.sh -h
    Usage: install [-t <tag>] [-d <dir>] [-s <dir>]
     -d dir     directory to download into [default: ~/.nsccli/bin]
     -s dir     directory in which to place a symlink to the binary
                [default: ~/bin] [use '-' to forcibly not place a symlink]
     -t tag     retrieve a tagged release instead of the latest