### PR TITLE
FIX #246 account/user with stored keys

### DIFF
--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -281,6 +281,8 @@ func (p *AddUserParams) Run(ctx ActionCtx) (store.Status, error) {
 	// if they gave us a seed, it stored - try to get it
 	ks := ctx.StoreCtx().KeyStore
 	if ks.HasPrivateKey(pk) {
+		// we may have it - but the key we got is possibly a pub only - resolve it from the store.
+		p.kp, _ = ks.GetKeyPair(pk)
 		d, err := GenerateConfig(ctx.StoreCtx().Store, p.AccountContextParams.Name, p.userName, p.kp)
 		if err != nil {
 			r.AddError("unable to save creds: %v", err)

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -326,4 +327,16 @@ func Test_AddUserWithInteractiveCustomKey(t *testing.T) {
 	require.Equal(t, pk, uc.Subject)
 	require.Empty(t, uc.IssuerAccount)
 	require.False(t, ts.KeyStore.HasPrivateKey(pk))
+}
+
+func Test_AddUserWithExistingNkey(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	ts.AddAccount(t, "A")
+
+	_, stderr, err := ExecuteCmd(createGenerateNKeyCmd(), "--user", "--store")
+	require.NoError(t, err)
+	pk := strings.Split(stderr, "\n")[1]
+	_, _, err = ExecuteCmd(CreateAddUserCmd(), "U", "--public-key", pk)
+	require.NoError(t, err)
 }

--- a/cmd/signerparams.go
+++ b/cmd/signerparams.go
@@ -174,6 +174,28 @@ func (p *SignerParams) Resolve(ctx ActionCtx) error {
 
 func (p *SignerParams) ForceManagedAccountKey(ctx ActionCtx, kp nkeys.KeyPair) {
 	if ctx.StoreCtx().Store.IsManaged() && p.signerKP == nil {
+		// use the account as the signer
 		p.signerKP = kp
+		// check we have a private key available
+		pk, _ := p.signerKP.PrivateKey()
+		if pk == nil {
+			// try to load it
+			pub, _ := p.signerKP.PublicKey()
+			kp, err := ctx.StoreCtx().KeyStore.GetKeyPair(pub)
+			if err == nil {
+				pk, _ := kp.PrivateKey()
+				if pk != nil {
+					p.signerKP = kp
+				}
+			}
+		}
 	}
+}
+
+func (p *SignerParams) canSign(nk nkeys.KeyPair) bool {
+	if nk == nil {
+		return false
+	}
+	pk, _ := nk.PrivateKey()
+	return pk != nil
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -701,6 +701,10 @@ func RunTestAccountServerWithOperatorKP(t *testing.T, okp nkeys.KeyPair) (*httpt
 				ok = ac.SigningKeys.Contains(ac.Issuer)
 			}
 
+			// store a copy of the source jwt that we can inspect
+			orig := fmt.Sprintf("SRC_%s", ac.Subject)
+			storage[orig] = body
+
 			if ok {
 				ac.Limits.Conn = -1
 				ac.Limits.Data = -1


### PR DESCRIPTION
creating a user or a managed account by specifying a public key that is stored in the keystore will fail generation of creds or creation of the account.