### PR TITLE
Add env variables to prevent certain user behaviours

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -33,6 +33,9 @@ import (
 
 //NscHomeEnv the folder for the config file
 const NscHomeEnv = "NSC_HOME"
+const NscCwdOnlyEnv = "NSC_CWD_ONLY"
+const NscNoSelfUpdateEnv = "NSC_NO_SELF_UPDATE"
+const NscNoGitIgnoreEnv = "NSC_NO_GIT_IGNORE"
 
 type ToolConfig struct {
 	ContextConfig
@@ -228,6 +231,10 @@ func (d *ToolConfig) SetVersion(version string) {
 }
 
 func (d *ToolConfig) load() error {
+	if NscCwdOnly {
+		// don't read it
+		return nil
+	}
 	err := ReadJson(d.configFile(), &config)
 	if err != nil && os.IsNotExist(err) {
 		return nil
@@ -237,7 +244,10 @@ func (d *ToolConfig) load() error {
 
 func (d *ToolConfig) Save() error {
 	d.SetDefaults()
-	return WriteJson(d.configFile(), d)
+	if !NscCwdOnly {
+		return WriteJson(d.configFile(), d)
+	}
+	return nil
 }
 
 // GetToolHome returns the . folder used fro this CLIs config and optionally the projects

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNoGitIgnore(t *testing.T) {
+	require.NoError(t, os.Setenv(NscNoGitIgnoreEnv, "true"))
+	defer func() {
+		require.NoError(t, os.Unsetenv(NscNoGitIgnoreEnv))
+	}()
+	SetEnvOptions()
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	ts.DoesNotExist(t, filepath.Join(ts.Dir, "keys", ".gitignore"))
+}
+
+func TestCwdOnly(t *testing.T) {
+	require.NoError(t, os.Setenv(NscCwdOnlyEnv, "true"))
+	defer func() {
+		require.NoError(t, os.Unsetenv(NscCwdOnlyEnv))
+	}()
+	SetEnvOptions()
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, stderr, err := ExecuteCmd(GetRootCmd(), "env")
+	require.NoError(t, err)
+	stderr = StripTableDecorations(stderr)
+	require.Contains(t, stderr, "$NSC_CWD_ONLY Yes")
+
+	_, _, err = ExecuteCmd(createEnvCmd(), "--account", "A")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "$NSC_CWD_ONLY is set")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,6 +35,8 @@ const TestEnv = "NSC_TEST"
 
 var KeyPathFlag string
 var InteractiveFlag bool
+var NscNoSelfUpdate bool
+var NscCwdOnly bool
 var quietMode bool
 
 var cfgFile string
@@ -159,7 +161,20 @@ func ExecuteWithWriter(out io.Writer) error {
 	return nil
 }
 
+func SetEnvOptions() {
+	if _, ok := os.LookupEnv(NscNoGitIgnoreEnv); ok {
+		store.NscNotGitIgnore = true
+	}
+	if _, ok := os.LookupEnv(NscNoSelfUpdateEnv); ok {
+		NscNoSelfUpdate = true
+	}
+	if _, ok := os.LookupEnv(NscCwdOnlyEnv); ok {
+		NscCwdOnly = true
+	}
+}
+
 func init() {
+	SetEnvOptions()
 	cobra.OnInitialize(initConfig)
 	HoistRootFlags(GetRootCmd())
 }

--- a/cmd/store/keys.go
+++ b/cmd/store/keys.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -28,6 +28,8 @@ import (
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nuid"
 )
+
+var NscNotGitIgnore bool
 
 const DefaultNKeysPath = ".nkeys"
 const NKeysPathEnv = "NKEYS_PATH"
@@ -322,6 +324,9 @@ func (k *KeyStore) Remove(pubkey string) error {
 }
 
 func AddGitIgnore(dir string) error {
+	if NscNotGitIgnore {
+		return nil
+	}
 	if dir != "" {
 		_, err := os.Stat(dir)
 		if err != nil {

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -122,6 +122,9 @@ func (u *SelfUpdate) Run() (*semver.Version, error) {
 }
 
 func (u *SelfUpdate) shouldCheck() bool {
+	if NscNoSelfUpdate {
+		return false
+	}
 	have := semver.MustParse(GetRootCmd().Version).String()
 	if have == "0.0.0-dev" {
 		return false

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -68,6 +68,8 @@ func ResetSharedFlags() {
 
 func NewEmptyStore(t *testing.T) *TestStore {
 	ResetForTests()
+	// init runs early
+	SetEnvOptions()
 	var ts TestStore
 
 	// ngsStore is a global - so first test to get it initializes it
@@ -96,6 +98,8 @@ func NewEmptyStore(t *testing.T) *TestStore {
 
 func NewTestStoreWithOperator(t *testing.T, operatorName string, operator nkeys.KeyPair) *TestStore {
 	ResetForTests()
+	// init runs early
+	SetEnvOptions()
 	var ts TestStore
 
 	// ngsStore is a global - so first test to get it initializes it
@@ -636,7 +640,7 @@ func (ts *TestStore) VerifyUser(t *testing.T, operator string, account string, u
 
 func (ts *TestStore) DoesNotExist(t *testing.T, fp string) {
 	_, err := os.Stat(fp)
-	require.False(t, os.IsExist(err))
+	require.True(t, os.IsNotExist(err), fmt.Sprintf("should not exist %s", fp))
 }
 
 func Test_Util(t *testing.T) {

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,6 @@ github.com/nats-io/cliprompts/v2 v2.0.0-20191226174129-372d79b36768 h1:sdr8zfPeN
 github.com/nats-io/cliprompts/v2 v2.0.0-20191226174129-372d79b36768/go.mod h1:oweZn7AeaVJYKlNHfCIhznJVsdySLSng55vfuINE/d0=
 github.com/nats-io/jwt v0.2.6 h1:eAyoYvGgGLXR2EpnsBUvi/FcFrBqN6YKFVbOoEfPN4k=
 github.com/nats-io/jwt v0.2.6/go.mod h1:mQxQ0uHQ9FhEVPIcTSKwx2lqZEpXWWcCgA7R6NrWvvY=
-github.com/nats-io/jwt v0.3.2 h1:+RB5hMpXUUA2dfxuhBTEkMOrYmM+gKIZYS1KjSostMI=
-github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
 github.com/nats-io/jwt v0.3.3-0.20200519195258-f2bf5ce574c7 h1:RnGotxlghqR5D2KDAu4TyuLqyjuylOsJiAFhXvMvQIc=
 github.com/nats-io/jwt v0.3.3-0.20200519195258-f2bf5ce574c7/go.mod h1:n3cvmLfBfnpV4JJRN7lRYCyZnw48ksGsbThGXEk4w9M=
 github.com/nats-io/nats-server/v2 v2.0.1-0.20190625001713-2db76bde3329 h1:RjMdWlS/avIVeXLjWxrHmxoiNPcvLXVWqpO7Bp6hyTk=
@@ -78,8 +76,6 @@ github.com/nats-io/nats.go v1.8.1 h1:6lF/f1/NN6kzUDBz6pyvQDEXO39jqXcWRLu/tKjtOUQ
 github.com/nats-io/nats.go v1.8.1/go.mod h1:BrFz9vVn0fU3AcH9Vn4Kd7W0NpJ651tD5omQ3M8LwxM=
 github.com/nats-io/nkeys v0.0.2 h1:+qM7QpgXnvDDixitZtQUBDY9w/s9mu1ghS+JIbsrx6M=
 github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7TDb/4=
-github.com/nats-io/nkeys v0.1.3 h1:6JrEfig+HzTH85yxzhSVbjHRJv9cn0p6n3IngIcM5/k=
-github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.4 h1:aEsHIssIk6ETN5m2/MD8Y4B2X7FfXrBAUdkyRvbVYzA=
 github.com/nats-io/nkeys v0.1.4/go.mod h1:XdZpAbhgyyODYqjTawOnIOI7VlbKSarI9Gfy1tqEu/s=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
@@ -130,8 +126,6 @@ golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 h1:HuIa8hRrWRSrqYzx1qI49NNxhdi2PrY7gxVSq1JjLDc=
-golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
 golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=


### PR DESCRIPTION
FIX #240 - Added env variables to prevent the creation of `.gitignore`, performing self-update checks, or writing ~/.nsc.json.

- `$NSC_CWD_ONLY` - when set the context is based on the location of the CWD (operator/account).
- `$NSC_NO_SELF_UPDATE` - when set will skip any self-update checks
- `$NSC_NO_GIT_IGNORE` - when set will not write .gitignore files in the directory pointed to by - `$NKEYS_PATH`. If the nkeys are in a directory under revision control, it means that the secrets will be checked in. Exercise caution.

