### PR TITLE
Exposed account flag in delete user command

### DIFF
--- a/cmd/deleteuser.go
+++ b/cmd/deleteuser.go
@@ -42,6 +42,7 @@ nsc delete user -i`,
 	cmd.Flags().BoolVarP(&params.revoke, "revoke", "R", false, "revoke user before deleting")
 	cmd.Flags().BoolVarP(&params.rmNKey, "rm-nkey", "D", false, "delete the user key")
 	cmd.Flags().BoolVarP(&params.rmCreds, "rm-creds", "C", false, "delete the user creds")
+	params.AccountContextParams.BindFlags(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
Account Name flag (`-a`,`--account`)  of AccountContextParams wasn't added to cobra command flags