### PR TITLE
seed prints when invoking `nsc generate nkey --xxxx --store

### DIFF
--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -1,25 +1,22 @@
 /*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2018-2019 The NATS Authors
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package cmd
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/nats-io/jwt"
@@ -165,9 +162,14 @@ func Test_AddAccountNameArg(t *testing.T) {
 func Test_AddAccountWithExistingKey(t *testing.T) {
 	ts := NewTestStore(t, "O")
 	defer ts.Done(t)
-	_, stderr, err := ExecuteCmd(createGenerateNKeyCmd(), "--account", "--store")
+
+	kp, err := nkeys.CreateAccount()
 	require.NoError(t, err)
-	pk := strings.Split(stderr, "\n")[1]
+	_, err = ts.KeyStore.Store(kp)
+	require.NoError(t, err)
+	pk, err := kp.PublicKey()
+	require.NoError(t, err)
+
 	_, _, err = ExecuteCmd(CreateAddAccountCmd(), "A", "--public-key", pk)
 	require.NoError(t, err)
 }
@@ -179,9 +181,13 @@ func Test_AddManagedAccountWithExistingKey(t *testing.T) {
 	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	defer ts.Done(t)
 
-	_, stderr, err := ExecuteCmd(createGenerateNKeyCmd(), "--account", "--store")
+	kp, err := nkeys.CreateAccount()
 	require.NoError(t, err)
-	pk := strings.Split(stderr, "\n")[1]
+	_, err = ts.KeyStore.Store(kp)
+	require.NoError(t, err)
+	pk, err := kp.PublicKey()
+	require.NoError(t, err)
+
 	_, _, err = ExecuteCmd(CreateAddAccountCmd(), "A", "--public-key", pk)
 	require.NoError(t, err)
 

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -333,9 +332,13 @@ func Test_AddUserWithExistingNkey(t *testing.T) {
 	defer ts.Done(t)
 	ts.AddAccount(t, "A")
 
-	_, stderr, err := ExecuteCmd(createGenerateNKeyCmd(), "--user", "--store")
+	kp, err := nkeys.CreateUser()
 	require.NoError(t, err)
-	pk := strings.Split(stderr, "\n")[1]
+	_, err = ts.KeyStore.Store(kp)
+	require.NoError(t, err)
+	pk, err := kp.PublicKey()
+	require.NoError(t, err)
+
 	_, _, err = ExecuteCmd(CreateAddUserCmd(), "U", "--public-key", pk)
 	require.NoError(t, err)
 }

--- a/cmd/generatenkey.go
+++ b/cmd/generatenkey.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -83,21 +83,28 @@ func (e *KP) Generate() error {
 	return err
 }
 
-func (e *KP) String() string {
+func (e *KP) String(pubOnly bool) string {
 	if e.kp != nil {
-		seed, err := e.kp.Seed()
-		if err != nil {
-			return ""
+		if pubOnly {
+			pk, err := e.kp.PublicKey()
+			if err != nil {
+				return ""
+			}
+			return fmt.Sprintf("%s\n%s key stored %s\n", pk, e.kind(), e.fp)
+		} else {
+			seed, err := e.kp.Seed()
+			if err != nil {
+				return ""
+			}
+			pk, err := e.kp.PublicKey()
+			if err != nil {
+				return ""
+			}
+			if e.fp == "" {
+				return fmt.Sprintf("%s\n%s\n", string(seed), pk)
+			}
+			return fmt.Sprintf("%s\n%s\n%s key stored %s\n", string(seed), pk, e.kind(), e.fp)
 		}
-		pk, err := e.kp.PublicKey()
-		if err != nil {
-			return ""
-		}
-		if e.fp == "" {
-			return fmt.Sprintf("%s\n%s\n", string(seed), pk)
-		}
-		return fmt.Sprintf("%s\n%s\n%s key stored %s\n", string(seed), pk, e.kind(), e.fp)
-
 	}
 	return ""
 }
@@ -140,7 +147,7 @@ func (p *GenerateNKeysParam) Run(ctx ActionCtx) (store.Status, error) {
 					return nil, err
 				}
 			}
-			ctx.CurrentCmd().Println(j.String())
+			ctx.CurrentCmd().Println(j.String(p.store))
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
[fix] removed printing of seed key when storing a generated key. If the `--store` is not specified, the seed is printed.
