### PR TITLE
Generate system account and user on init and add operator

### DIFF
--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -40,11 +40,14 @@ func Test_AddOperator(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, _, err = ExecuteCmd(createAddOperatorCmd(), "--name", "O")
+	_, _, err = ExecuteCmd(createAddOperatorCmd(), "--name", "O", "--sys")
 	require.NoError(t, err)
 
 	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", ".nsc"))
 	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", "O.jwt"))
+
+	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", "accounts", "SYS", "SYS.jwt"))
+	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", "accounts", "SYS", "users", "sys.jwt"))
 }
 
 func TestImportOperator(t *testing.T) {
@@ -83,7 +86,7 @@ func TestAddOperatorInteractive(t *testing.T) {
 	ts := NewEmptyStore(t)
 	defer ts.Done(t)
 
-	_, _, err := ExecuteInteractiveCmd(createAddOperatorCmd(), []interface{}{false, "O", "2019-12-01", "2029-12-01", true})
+	_, _, err := ExecuteInteractiveCmd(createAddOperatorCmd(), []interface{}{false, "O", "2019-12-01", "2029-12-01", true, true})
 	require.NoError(t, err)
 	d, err := Read(filepath.Join(ts.Dir, "store", "O", "O.jwt"))
 	require.NoError(t, err)
@@ -99,6 +102,10 @@ func TestAddOperatorInteractive(t *testing.T) {
 	require.Equal(t, 2029, expiry.Year())
 	require.Equal(t, time.Month(12), expiry.Month())
 	require.Equal(t, 1, expiry.Day())
+	require.NotEmpty(t, oc.SystemAccount)
+
+	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", "accounts", "SYS", "SYS.jwt"))
+	require.FileExists(t, filepath.Join(ts.Dir, "store", "O", "accounts", "SYS", "users", "sys.jwt"))
 }
 
 func TestImportOperatorInteractive(t *testing.T) {
@@ -178,7 +185,7 @@ func Test_AddOperatorWithKeyInteractive(t *testing.T) {
 	cmd := createAddOperatorCmd()
 	HoistRootFlags(cmd)
 
-	args := []interface{}{false, "T", "0", "0", false, string(seed)}
+	args := []interface{}{false, "T", "0", "0", false, false, string(seed)}
 	_, _, err := ExecuteInteractiveCmd(cmd, args)
 	require.NoError(t, err)
 

--- a/cmd/describer.go
+++ b/cmd/describer.go
@@ -425,6 +425,10 @@ func (o *OperatorDescriber) Describe() string {
 
 	AddListValues(table, "Operator Service URLs", o.OperatorServiceURLs)
 
+	if o.SystemAccount != "" {
+		table.AddRow("System Account", o.SystemAccount)
+	}
+
 	if len(o.Identities) > 0 {
 		table.AddSeparator()
 		for _, v := range o.Identities {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -33,6 +33,8 @@ func Test_InitLocal(t *testing.T) {
 	ts.VerifyOperator(t, "O", false)
 	ts.VerifyAccount(t, "O", "O", true)
 	ts.VerifyUser(t, "O", "O", "O", true)
+	ts.VerifyAccount(t, "O", "SYS", true)
+	ts.VerifyUser(t, "O", "SYS", "sys", true)
 }
 
 func Test_InitExists(t *testing.T) {
@@ -217,6 +219,8 @@ func Test_InitLocalInteractive(t *testing.T) {
 	ts.VerifyOperator(t, "O", false)
 	ts.VerifyAccount(t, "O", "O", true)
 	ts.VerifyUser(t, "O", "O", "O", true)
+	ts.VerifyAccount(t, "O", "SYS", true)
+	ts.VerifyUser(t, "O", "SYS", "sys", true)
 }
 
 func Test_InitCustomInteractive(t *testing.T) {


### PR DESCRIPTION
Named SYS and sys

Signed-off-by: Matthias Hanel <mh@synadia.com>


```
16:32:01  ~/repos/nsc  system_account *9 ?1  nsc init
? enter a configuration directory /Users/matthiashanel/nsc-test
? Select an operator Create Operator
? name your operator, account and user crazy_brahmagupta
[ OK ] created operator crazy_brahmagupta
[ OK ] created system_account: name:SYS id:ADLPUC4CEHJY2NLBV3ILXYGVHR42ZVHCX7Q2OEMCFCNYUNPFETXI2DAG
[ OK ] created system account user: name:sys id:UALD37FFZD7HNO7IKBW7KOGAW6BONFQAWKQI54UAHNUUBT4QNSGPUG4F
[ OK ] system account user creds file stored in `~/.nkeys/creds/crazy_brahmagupta/SYS/sys.creds`
[ OK ] created account crazy_brahmagupta
[ OK ] created user "crazy_brahmagupta"
[ OK ] project jwt files created in `~/nsc-test`
[ OK ] user creds file stored in `~/.nkeys/creds/crazy_brahmagupta/crazy_brahmagupta/crazy_brahmagupta.creds`
> to run a local server using this configuration, enter:
>   nsc generate config --mem-resolver --config-file <path/server.conf>
> then start a nats-server using the generated config:
>   nats-server -c <path/server.conf>
all jobs succeeded
 16:32:15  ~/repos/nsc  system_account *9 ?1  nsc describe operator crazy_brahmagupta
╭──────────────────────────────────────────────────────────────────────────────────╮
│                                 Operator Details                                 │
├───────────────────────┬──────────────────────────────────────────────────────────┤
│ Name                  │ crazy_brahmagupta                                        │
│ Operator ID           │ ODI6CWZB53RMWHBXHPGOW6VALIFE7B3YPKPTNF3MEF3OTTTCZXFG2WN5 │
│ Issuer ID             │ ODI6CWZB53RMWHBXHPGOW6VALIFE7B3YPKPTNF3MEF3OTTTCZXFG2WN5 │
│ Issued                │ 2020-09-09 20:32:05 UTC                                  │
│ Expires               │                                                          │
│ Operator Service URLs │ nats://localhost:4222                                    │
│ System Account        │ ADLPUC4CEHJY2NLBV3ILXYGVHR42ZVHCX7Q2OEMCFCNYUNPFETXI2DAG │
╰───────────────────────┴──────────────────────────────────────────────────────────╯
 16:32:53  ✘ 1  ~/repos/nsc  system_account *9 ?1  nsc add operator -n test3 -s
[ OK ] generated and stored operator key "ODIIETQPK7RV3IQK3675Y553RZ7ST2PU4ICPYPIOVGAA5GHT7R7RVOWM"
[ OK ] added operator "test3"
[ OK ] created system_account: name:SYS id:ABBYA7BW3OCTRL76JFP4BRWIRB2G53XUAHTK5JG4VW34VAB4HOZGFND7
[ OK ] created system account user: name:sys id:UADSO5EEDMUNTAQIAHOSCDZM7GDREGXYDQBRMJVKGJXSTSSKBP2G4CEK
[ OK ] system account user creds file stored in `~/.nkeys/creds/test3/SYS/sys.creds`
 16:32:58  ~/repos/nsc  system_account *9 ?1  nsc describe operator test3
╭───────────────────────────────────────────────────────────────────────────╮
│                             Operator Details                              │
├────────────────┬──────────────────────────────────────────────────────────┤
│ Name           │ test3                                                    │
│ Operator ID    │ ODIIETQPK7RV3IQK3675Y553RZ7ST2PU4ICPYPIOVGAA5GHT7R7RVOWM │
│ Issuer ID      │ ODIIETQPK7RV3IQK3675Y553RZ7ST2PU4ICPYPIOVGAA5GHT7R7RVOWM │
│ Issued         │ 2020-09-09 20:32:53 UTC                                  │
│ Expires        │                                                          │
│ System Account │ ABBYA7BW3OCTRL76JFP4BRWIRB2G53XUAHTK5JG4VW34VAB4HOZGFND7 │
╰────────────────┴──────────────────────────────────────────────────────────╯
 16:32:59  ~/repos/nsc  system_account *9 ?1 
```