### PR TITLE
Return struct instead of interface to avoid comparing interface with nil

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -381,7 +381,7 @@ func (p *InitCmdParams) setOperatorDefaults(ctx ActionCtx) error {
 	return nil
 }
 
-func (p *InitCmdParams) createAccount(ctx ActionCtx) (store.Status, error) {
+func (p *InitCmdParams) createAccount(ctx ActionCtx) (*store.Report, error) {
 	var err error
 	p.Account.KP, err = nkeys.CreateAccount()
 	if err != nil {

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -401,7 +401,7 @@ func (s *Store) handleManagedAccount(data []byte) (*Report, error) {
 	return r, nil
 }
 
-func (s *Store) StoreClaim(data []byte) (Status, error) {
+func (s *Store) StoreClaim(data []byte) (*Report, error) {
 	ct, err := s.ClaimType(data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Signed-off-by: Matthias Hanel <mh@synadia.com>