### PR TITLE
[changed] managed accounts to save self-signed accounts if failed to …

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -460,8 +460,7 @@ func OperatorJwtURL(oc *jwt.OperatorClaims) (string, error) {
 }
 
 func IsNatsUrl(url string) bool {
-	url = strings.ToLower(strings.TrimSpace(url))
-	return strings.HasPrefix(url, "nats://") || strings.HasPrefix(url, ",nats://")
+	return store.IsNatsUrl(url)
 }
 
 func ValidSigner(kp nkeys.KeyPair, signers []string) (bool, error) {

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -362,6 +362,11 @@ func PushAccount(u string, data []byte) (Status, error) {
 	return PushReport(resp.StatusCode, message), err
 }
 
+func IsNatsUrl(url string) bool {
+	url = strings.ToLower(strings.TrimSpace(url))
+	return strings.HasPrefix(url, "nats://") || strings.HasPrefix(url, ",nats://")
+}
+
 func (s *Store) handleManagedAccount(data []byte) (*Report, error) {
 	ac, err := jwt.DecodeAccountClaims(string(data))
 	if err != nil {
@@ -372,8 +377,11 @@ func (s *Store) handleManagedAccount(data []byte) (*Report, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to push to the operator - failed to read operator claim: %v", err)
 	}
-	if oc.AccountServerURL == "" {
-		return nil, fmt.Errorf("unable to push to %q - operator doesn't set an account server url", oc.Name)
+	r := NewDetailedReport(false)
+	if oc.AccountServerURL == "" || IsNatsUrl(oc.AccountServerURL) {
+		r.Label = "stored self signed account jwt"
+		r.AddWarning("unable to push to %q - operator doesn't set an account server url or manual exchange necessary", oc.Name)
+		return r, nil
 	}
 
 	u, err := url.Parse(oc.AccountServerURL)
@@ -381,7 +389,6 @@ func (s *Store) handleManagedAccount(data []byte) (*Report, error) {
 		return nil, fmt.Errorf("unable to push to the %q - failed to parse account server url (%q): %v", oc.Name, oc.AccountServerURL, err)
 	}
 
-	r := NewDetailedReport(false)
 	r.Label = "synchronized account jwt with account server"
 	// this is an url - join with path
 	u.Path = path.Join(u.Path, "accounts", ac.Subject)
@@ -408,12 +415,8 @@ func (s *Store) StoreClaim(data []byte) (*Report, error) {
 	}
 	if *ct == jwt.AccountClaim && s.IsManaged() {
 		var pull Report
-		var push Report
 		pp, err := s.handleManagedAccount(data)
 		if pp != nil {
-			if len(pp.Details) >= 1 {
-				push = *pp.Details[0].(*Report)
-			}
 			if len(pp.Details) >= 2 {
 				pull = *pp.Details[1].(*Report)
 			}
@@ -428,12 +431,13 @@ func (s *Store) StoreClaim(data []byte) (*Report, error) {
 				pp.AddError("failed to store jwt: %v", err)
 				return pp, err
 			}
-		} else if push.Code() == OK || push.Code() == WARN {
+		} else {
 			// Push OK but failed pull, store self-signed
 			if err := s.StoreRaw(data); err != nil {
 				pp.AddError("failed to store self-signed jwt: %v", err)
 				return pp, err
 			}
+			pp.AddWarning("perform push/pull again or exchange self-signed JWT manually")
 		}
 		return pp, nil
 	} else {


### PR DESCRIPTION
…push

Signed-off-by: Matthias Hanel <mh@synadia.com>

```bash
> nsc add account -n TE
[ OK ] generated and stored account key "AAU3GB7UGNLR6USU2IBEG2ATLG76EKCFEVGRQHUZSVM5ND4K2E6DCCCB"
[WARN] unable to push to "DEMO" - operator doesn't set an account server url or manual exchange necessary
[WARN] perform push/pull again or exchange self-signed JWT manually
[ OK ] added account "TE"
> nsc edit account --payload 10
[ OK ] changed max imports to 10
[WARN] unable to push to "DEMO" - operator doesn't set an account server url or manual exchange necessary
[WARN] perform push/pull again or exchange self-signed JWT manually
[ OK ] edited account "TE"
nsc delete account -n TE --force
[WARN] unable to push to "DEMO" - operator doesn't set an account server url or manual exchange necessary
[WARN] perform push/pull again or exchange self-signed JWT manually
[ OK ] expired account "TE"
[ OK ] deleted account
[ OK ] deleted account directory
>

#earlier tests with more commands, prior to changing report format
> nsc add account -n EVN2
[ OK ] generated and stored account key "ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW"
[WARN] unable to push to "DEMO" - operator doesn't set an account server url
[ OK ] added account "EVN2"
> nsc list accounts
╭─────────────────────────────────────────────────────────────────╮
│                            Accounts                             │
├──────┬──────────────────────────────────────────────────────────┤
│ Name │ Public Key                                               │
├──────┼──────────────────────────────────────────────────────────┤
│ EVN2 │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │
╰──────┴──────────────────────────────────────────────────────────╯

> nsc list keys --all
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│                                           Keys                                           │
├────────┬──────────────────────────────────────────────────────────┬─────────────┬────────┤
│ Entity │ Key                                                      │ Signing Key │ Stored │
├────────┼──────────────────────────────────────────────────────────┼─────────────┼────────┤
│ DEMO   │ OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB │             │        │
│  EVN2  │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │             │ *      │
╰────────┴──────────────────────────────────────────────────────────┴─────────────┴────────╯

> nsc describe account
╭──────────────────────────────────────────────────────────────────────────────────────╮
│                                   Account Details                                    │
├───────────────────────────┬──────────────────────────────────────────────────────────┤
│ Name                      │ EVN2                                                     │
│ Account ID                │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │
│ Issuer ID                 │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │
│ Issued                    │ 2020-10-27 21:27:51 UTC                                  │
│ Expires                   │                                                          │
├───────────────────────────┼──────────────────────────────────────────────────────────┤
│ Max Connections           │ Unlimited                                                │
│ Max Leaf Node Connections │ Unlimited                                                │
│ Max Data                  │ Unlimited                                                │
│ Max Exports               │ Unlimited                                                │
│ Max Imports               │ Unlimited                                                │
│ Max Msg Payload           │ Unlimited                                                │
│ Max Subscriptions         │ Unlimited                                                │
│ Exports Allows Wildcards  │ True                                                     │
├───────────────────────────┼──────────────────────────────────────────────────────────┤
│ Imports                   │ None                                                     │
│ Exports                   │ None                                                     │
╰───────────────────────────┴──────────────────────────────────────────────────────────╯
> nsc edit account --payload 10
[ OK ] changed max imports to 10
[WARN] unable to push to "DEMO" - operator doesn't set an account server url
[ OK ] edited account "EVN2"
> nsc describe account
╭──────────────────────────────────────────────────────────────────────────────────────╮
│                                   Account Details                                    │
├───────────────────────────┬──────────────────────────────────────────────────────────┤
│ Name                      │ EVN2                                                     │
│ Account ID                │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │
│ Issuer ID                 │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │
│ Issued                    │ 2020-10-27 21:28:42 UTC                                  │
│ Expires                   │                                                          │
├───────────────────────────┼──────────────────────────────────────────────────────────┤
│ Max Connections           │ Unlimited                                                │
│ Max Leaf Node Connections │ Unlimited                                                │
│ Max Data                  │ Unlimited                                                │
│ Max Exports               │ Unlimited                                                │
│ Max Imports               │ Unlimited                                                │
│ Max Msg Payload           │ 10 B (10 bytes)                                          │
│ Max Subscriptions         │ Unlimited                                                │
│ Exports Allows Wildcards  │ True                                                     │
├───────────────────────────┼──────────────────────────────────────────────────────────┤
│ Imports                   │ None                                                     │
│ Exports                   │ None                                                     │
╰───────────────────────────┴──────────────────────────────────────────────────────────╯
> nsc describe account  --raw
eyJ0eXAiOiJqd3QiLCJhbGciOiJlZDI1NTE5In0.eyJqdGkiOiI0Sk9QSkE0Nks2RjNWM1ZZQzMzM0hDR1g2M1lXWEJMNVVaTElUVExBWlFIMklUVVBQTlRRIiwiaWF0IjoxNjAzODM0MTIyLCJpc3MiOiJBQ0lDTldRNU9TVU02QVNTRTZKSkdLRkJZQUZWS01ERlNJR1lDVlA0RE9SNUlFRFRGWDJBTkdCVyIsIm5hbWUiOiJFVk4yIiwic3ViIjoiQUNJQ05XUTVPU1VNNkFTU0U2SkpHS0ZCWUFGVktNREZTSUdZQ1ZQNERPUjVJRURURlgyQU5HQlciLCJ0eXBlIjoiYWNjb3VudCIsIm5hdHMiOnsibGltaXRzIjp7InN1YnMiOi0xLCJjb25uIjotMSwibGVhZiI6LTEsImltcG9ydHMiOi0xLCJleHBvcnRzIjotMSwiZGF0YSI6LTEsInBheWxvYWQiOjEwLCJ3aWxkY2FyZHMiOnRydWV9fX0.cUY5SVSpI-HPFSb9P-_bs-wG8BFidePWgKyWIP-mbQO1wipQgqeBy218at25O5-X4qtcICdt0-jSAUZgTZ9ODg
> nsc list keys --all
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│                                           Keys                                           │
├────────┬──────────────────────────────────────────────────────────┬─────────────┬────────┤
│ Entity │ Key                                                      │ Signing Key │ Stored │
├────────┼──────────────────────────────────────────────────────────┼─────────────┼────────┤
│ DEMO   │ OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB │             │        │
│  EVN2  │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │             │ *      │
╰────────┴──────────────────────────────────────────────────────────┴─────────────┴────────╯

> nsc add user -n test
[ OK ] generated and stored user key "UA3IRY3ZPBINHLRV2YFRH425FHTBAVRRWEII2OWW5U2R6DUZPDE3F4IQ"
[ OK ] generated user creds file `~/test/demo/env2/keys/creds/DEMO/EVN2/test.creds`
[ OK ] added user "test" to account "EVN2"
> nsc list keys --all
╭──────────────────────────────────────────────────────────────────────────────────────────╮
│                                           Keys                                           │
├────────┬──────────────────────────────────────────────────────────┬─────────────┬────────┤
│ Entity │ Key                                                      │ Signing Key │ Stored │
├────────┼──────────────────────────────────────────────────────────┼─────────────┼────────┤
│ DEMO   │ OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB │             │        │
│  EVN2  │ ACICNWQ5OSUM6ASSE6JJGKFBYAFVKMDFSIGYCVP4DOR5IEDTFX2ANGBW │             │ *      │
│   test │ UA3IRY3ZPBINHLRV2YFRH425FHTBAVRRWEII2OWW5U2R6DUZPDE3F4IQ │             │ *      │
╰────────┴──────────────────────────────────────────────────────────┴─────────────┴────────╯

>
```