### PR TITLE
[feat] Adding command to import account

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -478,6 +478,17 @@ func ValidSigner(kp nkeys.KeyPair, signers []string) (bool, error) {
 	return ok, nil
 }
 
+func GetOperatorSigners(ctx ActionCtx) ([]string, error) {
+	oc, err := ctx.StoreCtx().Store.ReadOperatorClaim()
+	if err != nil {
+		return nil, err
+	}
+	var signers []string
+	signers = append(signers, oc.Subject)
+	signers = append(signers, oc.SigningKeys...)
+	return signers, nil
+}
+
 func diffDates(format string, a, b int64) store.Status {
 	if a != b {
 		as := "always"

--- a/cmd/importaccount_test.go
+++ b/cmd/importaccount_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2020-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -47,12 +47,12 @@ func Test_ImportAccountSelfSigned(t *testing.T) {
 	file := filepath.Join(ts.Dir, "account-selfsigned.jwt")
 	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
 	require.NoError(t, err)
-	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--file", file)
 	require.NoError(t, err)
 	check()
-	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--file", file)
 	require.Error(t, err)
-	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file, "--overwrite")
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--file", file, "--overwrite")
 	require.NoError(t, err)
 	check()
 }
@@ -71,6 +71,6 @@ func Test_ImportAccountOtherOperator(t *testing.T) {
 	file := filepath.Join(ts.Dir, "account.jwt")
 	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
 	require.NoError(t, err)
-	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--file", file)
 	require.Error(t, err)
 }

--- a/cmd/importaccount_test.go
+++ b/cmd/importaccount_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ImportAccountSelfSigned(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	akp, _ := nkeys.CreateAccount()
+	pk, _ := akp.PublicKey()
+	ac := jwt.NewAccountClaims(pk)
+	ac.Name = ac.Subject
+	theJWT, err := ac.Encode(akp)
+	require.NoError(t, err)
+	require.True(t, ac.IsSelfSigned())
+
+	check := func() {
+		t.Helper()
+		claim, err := ts.Store.ReadAccountClaim(pk)
+		require.NoError(t, err)
+		require.False(t, claim.IsSelfSigned())
+	}
+
+	file := filepath.Join(ts.Dir, "account-selfsigned.jwt")
+	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
+	require.NoError(t, err)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	require.NoError(t, err)
+	check()
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	require.Error(t, err)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file, "--overwrite")
+	require.NoError(t, err)
+	check()
+}
+
+func Test_ImportAccountOtherOperator(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	oKp, _ := nkeys.CreateOperator()
+	akp, _ := nkeys.CreateAccount()
+	pk, _ := akp.PublicKey()
+	ac := jwt.NewAccountClaims(pk)
+	ac.Name = ac.Subject
+	theJWT, err := ac.Encode(oKp)
+	require.NoError(t, err)
+	require.False(t, ac.IsSelfSigned())
+	file := filepath.Join(ts.Dir, "account.jwt")
+	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
+	require.NoError(t, err)
+	_, _, err = ExecuteCmd(createImportAccountCmd(), "--jwt", file)
+	require.Error(t, err)
+}

--- a/cmd/importuser.go
+++ b/cmd/importuser.go
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
+	"github.com/nats-io/nsc/cmd/store"
+	"github.com/spf13/cobra"
+)
+
+func createImportUserCmd() *cobra.Command {
+	var params ImportUser
+	cmd := &cobra.Command{
+		Use:          "user --file <user-jwt/user-creds>",
+		Short:        "Imports an account from a jwt or account and nkey from a creds file",
+		Example:      `nsc import account --jwt <account-jwt>`,
+		Args:         MaxArgs(0),
+		SilenceUsage: false,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := RunMaybeStorelessAction(cmd, args, &params); err != nil {
+				return err
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&params.skip, "skip", "", false, "skip validation issues")
+	cmd.Flags().BoolVarP(&params.overwrite, "overwrite", "", false, "overwrite existing user")
+	cmd.Flags().StringVarP(&params.file, "file", "f", "", "user jwt or creds to import")
+	cmd.MarkFlagRequired("file")
+	return cmd
+}
+
+func init() {
+	importCmd.AddCommand(createImportUserCmd())
+}
+
+type ImportUser fileImport
+
+func (p *ImportUser) SetDefaults(ctx ActionCtx) error {
+	return nil
+}
+
+func (p *ImportUser) PreInteractive(ctx ActionCtx) error {
+	return nil
+}
+
+func (p *ImportUser) Load(ctx ActionCtx) error {
+	return nil
+}
+
+func (p *ImportUser) PostInteractive(ctx ActionCtx) error {
+	return nil
+}
+
+func (p *ImportUser) Validate(ctx ActionCtx) error {
+	fi, err := os.Stat(p.file)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		return fmt.Errorf("%#q is a directory", p.file)
+	}
+	if !(strings.HasSuffix(p.file, ".jwt") || strings.HasSuffix(p.file, ".creds")) {
+		return fmt.Errorf("expected .jwt or .creds file")
+	}
+	return nil
+}
+
+// returns true when blocking and not skipped
+func validateAndReport(claim jwt.Claims, force bool, r *store.Report) bool {
+	vr := jwt.ValidationResults{}
+	claim.Validate(&vr)
+	for _, i := range vr.Issues {
+		if i.Blocking {
+			r.AddError("Validation resulted in: %s", i.Description)
+		} else {
+			r.AddWarning("Validation resulted in: %s", i.Description)
+		}
+	}
+	if vr.IsBlocking(true) && !force {
+		r.AddError("Validation is blocking, skip with --skip")
+		return true
+	}
+	return false
+}
+
+func (p *ImportUser) Run(ctx ActionCtx) (store.Status, error) {
+	r := store.NewDetailedReport(true)
+	content, err := ioutil.ReadFile(p.file)
+	if err != nil {
+		r.AddError("failed to import %#q: %v", p.file, err)
+		return r, err
+	}
+	theJWT := ""
+	var kp nkeys.KeyPair
+	if strings.HasSuffix(p.file, ".jwt") {
+		theJWT = string(content)
+	} else {
+		if theJWT, err = jwt.ParseDecoratedJWT(content); err == nil {
+			if kp, err = jwt.ParseDecoratedUserNKey(content); err != nil {
+				r.AddError("failed to parse decorated key in %#q: %v", p.file, err)
+				return r, err
+			}
+		}
+	}
+	claim, err := jwt.DecodeUserClaims(theJWT)
+	if err != nil {
+		r.AddError("failed to decode %#q: %v", p.file, err)
+		return r, err
+	}
+	if validateAndReport(claim, p.skip, r) {
+		return r, err
+	}
+	acc := claim.IssuerAccount
+	if acc == "" {
+		acc = claim.Issuer
+	}
+	var accClaim *jwt.AccountClaims
+	accs, _ := ctx.StoreCtx().Store.ListSubContainers(store.Accounts)
+	for _, accName := range accs {
+		accClaim, _ = ctx.StoreCtx().Store.ReadAccountClaim(accName)
+		if accClaim.Subject != acc {
+			accClaim = nil
+		} else {
+			break
+		}
+	}
+	if accClaim == nil {
+		r.AddError("Referenced Account %s not found, import first", acc)
+		return r, nil
+	}
+	if ctx.StoreCtx().Store.Has(store.Accounts, accClaim.Name, store.Users, store.JwtName(claim.Name)) {
+		if !p.overwrite {
+			r.AddError("User already exists, overwrite with --overwrite")
+			return r, nil
+		}
+		if old, err := ctx.StoreCtx().Store.ReadUserClaim(accClaim.Name, claim.Name); err != nil {
+			r.AddError("Existing User not found: %v", err)
+			return r, nil
+		} else if old.Subject != claim.Subject {
+			r.AddError("Existing User has a name collision only and does not reference the same entity "+
+				"(Subject is %s and differs from %s). This problem needs to be resolved manually.",
+				old.Subject, claim.Subject)
+			return r, nil
+		}
+	}
+	sameAccount := false
+	keys := []string{accClaim.Subject}
+	keys = append(keys, ([]string(accClaim.SigningKeys))...)
+	for _, key := range keys {
+		if key == claim.Issuer {
+			sameAccount = true
+			break
+		}
+	}
+	if !sameAccount {
+		r.AddError("Can only import user signed by exiting account. Possibly update your account")
+		return r, nil
+	}
+	if kp != nil {
+		keyPath, err := ctx.StoreCtx().KeyStore.Store(kp)
+		if err != nil {
+			r.AddError("Key could not be stored: %v", err)
+			return r, nil
+		}
+		r.AddOK("Key stored %s", keyPath)
+	}
+	sub, err := ctx.StoreCtx().Store.StoreClaim([]byte(theJWT))
+	if err != nil {
+		r.AddError("Error when storing user: %v", err)
+	}
+	r.Add(sub)
+	if r.HasNoErrors() {
+		r.AddOK("User %s was successfully imported", claim.Name)
+	} else {
+		r.AddOK("User %s was not imported: %v", claim.Name, err)
+	}
+	return r, nil
+}

--- a/cmd/importuser_test.go
+++ b/cmd/importuser_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2020-2020 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/cmd/importuser_test.go
+++ b/cmd/importuser_test.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2018-2020 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/nats-io/jwt"
+	"github.com/nats-io/nkeys"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ImportUserCreds(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", "acc")
+	require.NoError(t, err)
+	aClaim, _ := ts.Store.ReadAccountClaim("acc")
+	aKp, err := ts.KeyStore.GetKeyPair(aClaim.Subject)
+	require.NoError(t, err)
+
+	uKp, _ := nkeys.CreateUser()
+	pk, _ := uKp.PublicKey()
+	uc := jwt.NewUserClaims(pk)
+	uc.Name = uc.Subject
+	theJWT, err := uc.Encode(aKp)
+	require.NoError(t, err)
+	require.False(t, ts.KeyStore.HasPrivateKey(pk))
+
+	check := func() {
+		t.Helper()
+		_, err := ts.Store.ReadUserClaim("acc", pk)
+		require.NoError(t, err)
+		require.True(t, ts.KeyStore.HasPrivateKey(pk))
+	}
+
+	seed, err := uKp.Seed()
+	require.NoError(t, err)
+	creds, err := jwt.FormatUserConfig(theJWT, seed)
+	require.NoError(t, err)
+
+	file := filepath.Join(ts.Dir, "user.creds")
+	err = ioutil.WriteFile(file, creds, 0666)
+	require.NoError(t, err)
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file)
+	require.NoError(t, err)
+	check()
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file)
+	require.Error(t, err)
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file, "--overwrite")
+	require.NoError(t, err)
+	check()
+}
+
+func Test_ImportUserJWT(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "--name", "acc")
+	require.NoError(t, err)
+
+	aClaim, _ := ts.Store.ReadAccountClaim("acc")
+	aKp, err := ts.KeyStore.GetKeyPair(aClaim.Subject)
+	require.NoError(t, err)
+
+	uKp, _ := nkeys.CreateUser()
+	pk, _ := uKp.PublicKey()
+	uc := jwt.NewUserClaims(pk)
+	uc.Name = uc.Subject
+	theJWT, err := uc.Encode(aKp)
+	require.NoError(t, err)
+
+	check := func() {
+		t.Helper()
+		_, err := ts.Store.ReadUserClaim("acc", pk)
+		require.NoError(t, err)
+	}
+
+	file := filepath.Join(ts.Dir, "user.jwt")
+	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
+	require.NoError(t, err)
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file)
+	require.NoError(t, err)
+	check()
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file)
+	require.Error(t, err)
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file, "--overwrite")
+	require.NoError(t, err)
+	check()
+}
+
+func Test_ImportUserOtherAccount(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	aKp, _ := nkeys.CreateAccount()
+	uKp, _ := nkeys.CreateUser()
+	pk, _ := uKp.PublicKey()
+	uc := jwt.NewUserClaims(pk)
+	uc.Name = uc.Subject
+	theJWT, err := uc.Encode(aKp)
+	require.NoError(t, err)
+	file := filepath.Join(ts.Dir, "user.jwt")
+	err = ioutil.WriteFile(file, []byte(theJWT), 0666)
+	require.NoError(t, err)
+	_, _, err = ExecuteCmd(createImportUserCmd(), "--file", file)
+	require.Error(t, err)
+}


### PR DESCRIPTION
If the account is self signed, resign with the operator.

Signed-off-by: Matthias Hanel <mh@synadia.com>

manual test:
```text
> nsc delete account ACC
[ OK ] expired account "ACC"
[ OK ] deleted account
[ OK ] deleted account directory
> nsc import account --jwt import.jwt
[WARN] Validation resulted in: self-signed account JWTs shouldn't contain operator limits
[ OK ] Account ACC was successfully imported
1 job succeeded - 1 have warnings
> nsc import account --jwt import.jwt
[WARN] Validation resulted in: self-signed account JWTs shouldn't contain operator limits
[ERR ] Account already exists, overwrite with --overwrite
Error: 1 job failed - 0 job succeeded and 1 had warnings
Usage:
  nsc import account <jwt file> [flags]

Examples:
nsc import account <jwt>

Flags:
  -h, --help         help for account
  -j, --jwt string   account jwt to import
      --overwrite    overwrite existing account
      --skip         skip validation issues

Global Flags:
  -i, --interactive          ask questions for various settings
  -K, --private-key string   private key

> nsc import account --jwt import.jwt  --overwrite
[WARN] Validation resulted in: self-signed account JWTs shouldn't contain operator limits
[ OK ] Account ACC was successfully imported
1 job succeeded - 1 have warnings
> git describe account -n ACC
fatal: not a git repository (or any of the parent directories): .git
> nsc describe account -n ACC
+--------------------------------------------------------------------------------------+
|                                   Account Details                                    |
+---------------------------+----------------------------------------------------------+
| Name                      | ACC                                                      |
| Account ID                | ADRB4JJYFDLWKIMX4DH6MX2DMKA3TENJWGMNVM5ILYLZTT6BN7QIF5ZX |
| Issuer ID                 | OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB |
| Issued                    | 2020-10-28 23:07:56 UTC                                  |
| Expires                   |                                                          |
+---------------------------+----------------------------------------------------------+
| Max Connections           | Unlimited                                                |
| Max Leaf Node Connections | Unlimited                                                |
| Max Data                  | Unlimited                                                |
| Max Exports               | Unlimited                                                |
| Max Imports               | Unlimited                                                |
| Max Msg Payload           | Unlimited                                                |
| Max Subscriptions         | Unlimited                                                |
| Exports Allows Wildcards  | True                                                     |
+---------------------------+----------------------------------------------------------+
| Imports                   | None                                                     |
| Exports                   | None                                                     |
+---------------------------+----------------------------------------------------------+
> nsc list keys --all
+------------------------------------------------------------------------------------------+
|                                           Keys                                           |
+--------+----------------------------------------------------------+-------------+--------+
| Entity | Key                                                      | Signing Key | Stored |
+--------+----------------------------------------------------------+-------------+--------+
| DEMO   | OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB |             | *      |
|  ACC   | ADRB4JJYFDLWKIMX4DH6MX2DMKA3TENJWGMNVM5ILYLZTT6BN7QIF5ZX |             |        |
|  SYS   | AAYVLZJC2ULKSH5HNSKMIKFMCEHCNU5VOV5KG56IRL7ENHLBUGZ27CZT |             | *      |
|   sys  | UBVZYLLCAFMHBXBUDKKKFKH62T4AW7Q5MAAE3R3KKAIRCZNYITZPDQZ3 |             | *      |
+--------+----------------------------------------------------------+-------------+--------+

>


```

import of account and user in managed store
```
> nsc import account --jwt ../env1/nats/DEMO/accounts/SYS/SYS.jwt
[WARN] unable to push to "DEMO" - operator doesn't set an account server url or manual exchange necessary
[WARN] perform push/pull again or exchange self-signed JWT manually
[ OK ] Account SYS was successfully imported
1 job succeeded - 1 have warnings
> nsc list keys --all
+------------------------------------------------------------------------------------------+
|                                           Keys                                           |
+--------+----------------------------------------------------------+-------------+--------+
| Entity | Key                                                      | Signing Key | Stored |
+--------+----------------------------------------------------------+-------------+--------+
| DEMO   | OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB |             |        |
|  ACC   | ADRB4JJYFDLWKIMX4DH6MX2DMKA3TENJWGMNVM5ILYLZTT6BN7QIF5ZX |             | *      |
|  SYS   | AAYVLZJC2ULKSH5HNSKMIKFMCEHCNU5VOV5KG56IRL7ENHLBUGZ27CZT |             |        |
+--------+----------------------------------------------------------+-------------+--------+

> nsc import account --jwt ../env1/nats/DEMO/accounts/SYS/SYS.jwt
[ERR ] Account already exists, overwrite with --overwrite
Error: all jobs failed
Usage:
  nsc import account --jwt <account-jwt> [flags]

Examples:
nsc import account --jwt <account-jwt>

Flags:
  -h, --help         help for account
  -j, --jwt string   account jwt to import
      --overwrite    overwrite existing account
      --skip         skip validation issues, they can be edited out

Global Flags:
  -i, --interactive          ask questions for various settings
  -K, --private-key string   private key

> nsc import user --file ../env1/nats/DEMO/accounts/SYS/users/sys.jwt
[ OK ] User sys was successfully imported
> nsc list keys --all
+------------------------------------------------------------------------------------------+
|                                           Keys                                           |
+--------+----------------------------------------------------------+-------------+--------+
| Entity | Key                                                      | Signing Key | Stored |
+--------+----------------------------------------------------------+-------------+--------+
| DEMO   | OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB |             |        |
|  ACC   | ADRB4JJYFDLWKIMX4DH6MX2DMKA3TENJWGMNVM5ILYLZTT6BN7QIF5ZX |             | *      |
|  SYS   | AAYVLZJC2ULKSH5HNSKMIKFMCEHCNU5VOV5KG56IRL7ENHLBUGZ27CZT |             |        |
|   sys  | UBVZYLLCAFMHBXBUDKKKFKH62T4AW7Q5MAAE3R3KKAIRCZNYITZPDQZ3 |             |        |
+--------+----------------------------------------------------------+-------------+--------+

> nsc import user --file ../env1/keys/creds/DEMO/SYS/sys.creds
[ERR ] User already exists, overwrite with --overwrite
Error: all jobs failed
Usage:
  nsc import user --file <user-jwt/user-creds> [flags]

Examples:
nsc import account --jwt <account-jwt>

Flags:
  -f, --file string   user jwt or creds to import
  -h, --help          help for user
      --overwrite     overwrite existing user
      --skip          skip validation issues

Global Flags:
  -i, --interactive          ask questions for various settings
  -K, --private-key string   private key

> nsc import user --file ../env1/keys/creds/DEMO/SYS/sys.creds --overwrite
[ OK ] Key stored /Users/matthiashanel/test/demo/env2/keys/keys/U/BV/UBVZYLLCAFMHBXBUDKKKFKH62T4AW7Q5MAAE3R3KKAIRCZNYITZPDQZ3.nk
[ OK ] User sys was successfully imported
all jobs succeeded
> nsc list keys --all
+------------------------------------------------------------------------------------------+
|                                           Keys                                           |
+--------+----------------------------------------------------------+-------------+--------+
| Entity | Key                                                      | Signing Key | Stored |
+--------+----------------------------------------------------------+-------------+--------+
| DEMO   | OD5FHU4LXGDSGDHO7UNRMLW6I36QX5VPJXRQHFHMRUIKSHOPEDSHVPBB |             |        |
|  ACC   | ADRB4JJYFDLWKIMX4DH6MX2DMKA3TENJWGMNVM5ILYLZTT6BN7QIF5ZX |             | *      |
|  SYS   | AAYVLZJC2ULKSH5HNSKMIKFMCEHCNU5VOV5KG56IRL7ENHLBUGZ27CZT |             |        |
|   sys  | UBVZYLLCAFMHBXBUDKKKFKH62T4AW7Q5MAAE3R3KKAIRCZNYITZPDQZ3 |             | *      |
+--------+----------------------------------------------------------+-------------+--------+

 >
```