### PR TITLE
[Fixed] managed stores with op signing key create signed accounts

### DIFF
--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -146,7 +146,7 @@ func Test_AddAccountManagedStoreWithSigningKey(t *testing.T) {
 	inputs := []interface{}{"A", true, "0", "0", 0, string(s1)}
 	_, _, err = ExecuteInteractiveCmd(HoistRootFlags(CreateAddAccountCmd()), inputs)
 	require.NoError(t, err)
-	accJWT, err := ioutil.ReadFile(filepath.Join(ts.Dir, "store", "O", "Accounts", "A", "A.jwt"))
+	accJWT, err := ioutil.ReadFile(filepath.Join(ts.Dir, "store", "O", "accounts", "A", "A.jwt"))
 	require.NoError(t, err)
 	ac, err := jwt.DecodeAccountClaims(string(accJWT))
 	require.NoError(t, err)
@@ -157,7 +157,7 @@ func Test_AddAccountManagedStoreWithSigningKey(t *testing.T) {
 	inputs = []interface{}{"B", true, "0", "0", 1, string(s1)}
 	_, _, err = ExecuteInteractiveCmd(HoistRootFlags(CreateAddAccountCmd()), inputs)
 	require.NoError(t, err)
-	accJWT, err = ioutil.ReadFile(filepath.Join(ts.Dir, "store", "O", "Accounts", "B", "B.jwt"))
+	accJWT, err = ioutil.ReadFile(filepath.Join(ts.Dir, "store", "O", "accounts", "B", "B.jwt"))
 	require.NoError(t, err)
 	ac, err = jwt.DecodeAccountClaims(string(accJWT))
 	require.NoError(t, err)

--- a/cmd/addimport_test.go
+++ b/cmd/addimport_test.go
@@ -399,7 +399,7 @@ func Test_AddImport_LocalImportsInteractive(t *testing.T) {
 	require.Equal(t, apub, ac.Imports[0].Account)
 
 	// B, pick, service q, name q service, local subj qq
-	input = []interface{}{1, true, 2, "q service", "qq"}
+	input = []interface{}{1, true, 2, "q service", "qq", 0}
 	_, _, err = ExecuteInteractiveCmd(cmd, input)
 	require.NoError(t, err)
 

--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -33,7 +33,6 @@ import (
 
 func Test_AddOperator(t *testing.T) {
 	ts := NewEmptyStore(t)
-	t.Log(ts.Dir)
 
 	_, err := os.Lstat(filepath.Join(ts.Dir, "store"))
 	if err != nil && !os.IsNotExist(err) {

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -250,7 +250,7 @@ func Test_AddUserWithInteractiveAccountCtx(t *testing.T) {
 	ts.AddAccount(t, "B")
 
 	// adding to user bb to B
-	inputs := []interface{}{1, "bb", true, "0", "0"}
+	inputs := []interface{}{1, "bb", true, "0", "0", 0}
 	cmd := CreateAddUserCmd()
 	HoistRootFlags(cmd)
 	_, _, err := ExecuteInteractiveCmd(cmd, inputs)
@@ -263,7 +263,7 @@ func Test_AddUserWithInteractiveAccountCtx(t *testing.T) {
 	require.Empty(t, uc.IssuerAccount)
 
 	// adding to user aa to A
-	inputs = []interface{}{0, "aa", true, "0", "0"}
+	inputs = []interface{}{0, "aa", true, "0", "0", 0}
 	_, _, err = ExecuteInteractiveCmd(cmd, inputs)
 	require.NoError(t, err)
 	apk := ts.GetAccountPublicKey(t, "A")

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -237,7 +237,7 @@ func NKeyValidator(kind nkeys.PrefixByte) cli.Validator {
 	}
 }
 
-func SeedNKeyValidatorMatching(kind nkeys.PrefixByte, pukeys []string) cli.Validator {
+func SeedNKeyValidatorMatching(pukeys []string, kinds ...nkeys.PrefixByte) cli.Validator {
 	return func(v string) error {
 		if v == "" {
 			return fmt.Errorf("value cannot be empty")
@@ -260,8 +260,17 @@ func SeedNKeyValidatorMatching(kind nkeys.PrefixByte, pukeys []string) cli.Valid
 		if err != nil {
 			return err
 		}
-		if t != kind {
-			return fmt.Errorf("specified key is not valid for an %s", kind.String())
+		foundKind := false
+		kindNames := []string{}
+		for _, kind := range kinds {
+			if t == kind {
+				foundKind = true
+				break
+			}
+			kindNames = append(kindNames, kind.String())
+		}
+		if !foundKind {
+			return fmt.Errorf("specified key is not valid for any of %v", kindNames)
 		}
 
 		pk, err := nk.PublicKey()

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -406,7 +406,7 @@ func Test_SeedNKeyValidatorMatching(t *testing.T) {
 		{string(as1), true},
 	}
 
-	fun := SeedNKeyValidatorMatching(nkeys.PrefixByteAccount, validPubs)
+	fun := SeedNKeyValidatorMatching(validPubs, nkeys.PrefixByteAccount)
 	for i, kt := range keyTests {
 		err := fun(kt.arg)
 		var failed bool

--- a/cmd/deleteexport_test.go
+++ b/cmd/deleteexport_test.go
@@ -66,7 +66,7 @@ func Test_DeleteExportInteractiveManagedStore(t *testing.T) {
 	cmd := createDeleteExportCmd()
 	HoistRootFlags(cmd)
 
-	input := []interface{}{0, 0, ts.GetAccountKeyPath(t, "A")}
+	input := []interface{}{0, 0, 0, ts.GetAccountKeyPath(t, "A")}
 	_, _, err := ExecuteInteractiveCmd(cmd, input)
 	require.NoError(t, err)
 

--- a/cmd/signerparams.go
+++ b/cmd/signerparams.go
@@ -22,22 +22,21 @@ import (
 
 	cli "github.com/nats-io/cliprompts/v2"
 	"github.com/nats-io/nkeys"
+	"github.com/nats-io/nsc/cmd/store"
 )
 
 // SignerParams is shared UI for a signer (-K flag). The key
 // for a signer is never generated and must be provided
 type SignerParams struct {
-	kind     nkeys.PrefixByte
+	kind     []nkeys.PrefixByte
 	signerKP nkeys.KeyPair
 	prompt   string
 }
 
 func (p *SignerParams) SetDefaults(kind nkeys.PrefixByte, allowManaged bool, ctx ActionCtx) {
-	p.kind = kind
-	if allowManaged {
-		if ctx.StoreCtx().Store.IsManaged() && p.kind == nkeys.PrefixByteOperator {
-			p.kind = nkeys.PrefixByteAccount
-		}
+	p.kind = append(p.kind, kind)
+	if allowManaged && ctx.StoreCtx().Store.IsManaged() && kind == nkeys.PrefixByteOperator {
+		p.kind = append(p.kind, nkeys.PrefixByteAccount)
 	}
 }
 
@@ -65,7 +64,7 @@ func (p *SignerParams) SelectFromSigners(ctx ActionCtx, signers []string) error 
 	// if we have more than one key, we prompt
 	if len(keys) == 1 && len(notFound) == 0 {
 		var err error
-		p.signerKP, err = ctx.StoreCtx().ResolveKey(p.kind, keys[0])
+		p.signerKP, err = ctx.StoreCtx().ResolveKey(keys[0], p.kind...)
 		if err != nil {
 			return err
 		}
@@ -86,17 +85,21 @@ func (p *SignerParams) SelectFromSigners(ctx ActionCtx, signers []string) error 
 		}
 		// if it is the extra option, ask for a path/key
 		if idx != -1 && choice == idx {
-			label := fmt.Sprintf("path to signer %s nkey or nkey", p.kind.String())
+			kinds := []string{}
+			for _, kind := range p.kind {
+				kinds = append(kinds, kind.String())
+			}
+			label := fmt.Sprintf("path to signer %s nkey or nkey", kinds)
 			// key must be one from signing keys
-			KeyPathFlag, err = cli.Prompt(label, "", cli.Val(SeedNKeyValidatorMatching(p.kind, signers)))
+			KeyPathFlag, err = cli.Prompt(label, "", cli.Val(SeedNKeyValidatorMatching(signers, p.kind...)))
 			if err != nil {
 				return err
 			}
-			p.signerKP, err = ctx.StoreCtx().ResolveKey(p.kind, KeyPathFlag)
+			p.signerKP, err = ctx.StoreCtx().ResolveKey(KeyPathFlag, p.kind...)
 			return err
 		} else {
 			// they picked one
-			p.signerKP, err = ctx.StoreCtx().ResolveKey(p.kind, keys[choice])
+			p.signerKP, err = ctx.StoreCtx().ResolveKey(keys[choice], p.kind...)
 			return err
 		}
 	}
@@ -107,7 +110,7 @@ func (p *SignerParams) SelectFromSigners(ctx ActionCtx, signers []string) error 
 func (p *SignerParams) Edit(ctx ActionCtx) error {
 	var err error
 	sctx := ctx.StoreCtx()
-	p.signerKP, _ = sctx.ResolveKey(p.kind, KeyPathFlag)
+	p.signerKP, _ = sctx.ResolveKey(KeyPathFlag, p.kind...)
 
 	if p.signerKP != nil && ctx.StoreCtx().Store.IsManaged() {
 		return nil
@@ -132,19 +135,22 @@ func (p *SignerParams) getSigners(ctx ActionCtx) ([]string, error) {
 	sctx := ctx.StoreCtx()
 	ks := sctx.KeyStore
 	var signers []string
-	var err error
-	switch p.kind {
-	case nkeys.PrefixByteOperator:
-		KeyPathFlag = ks.GetKeyPath(sctx.Operator.PublicKey)
-		signers, err = ctx.StoreCtx().GetOperatorKeys()
-		if err != nil {
-			return nil, err
-		}
-	case nkeys.PrefixByteAccount:
-		KeyPathFlag = ks.GetKeyPath(sctx.Account.PublicKey)
-		signers, err = ctx.StoreCtx().GetAccountKeys(sctx.Account.Name)
-		if err != nil {
-			return nil, err
+	for _, kind := range p.kind {
+		switch kind {
+		case nkeys.PrefixByteOperator:
+			KeyPathFlag = ks.GetKeyPath(sctx.Operator.PublicKey)
+			sgnrs, err := ctx.StoreCtx().GetOperatorKeys()
+			if err != nil {
+				return nil, err
+			}
+			signers = append(signers, sgnrs...)
+		case nkeys.PrefixByteAccount:
+			KeyPathFlag = ks.GetKeyPath(sctx.Account.PublicKey)
+			sgnrs, err := ctx.StoreCtx().GetAccountKeys(sctx.Account.Name)
+			if err != nil {
+				return nil, err
+			}
+			signers = append(signers, sgnrs...)
 		}
 	}
 	return signers, nil
@@ -157,7 +163,7 @@ func (p *SignerParams) Resolve(ctx ActionCtx) error {
 	var err error
 	// if they specified -K resolve or fail
 	if KeyPathFlag != "" {
-		p.signerKP, err = ctx.StoreCtx().ResolveKey(p.kind, KeyPathFlag)
+		p.signerKP, err = ctx.StoreCtx().ResolveKey(KeyPathFlag, p.kind...)
 		if err != nil {
 			return err
 		}
@@ -187,25 +193,33 @@ func (p *SignerParams) Resolve(ctx ActionCtx) error {
 	if selected == "" {
 		return fmt.Errorf("unable to resolve any of the following signing keys in the keystore: %s", strings.Join(signers, ", "))
 	}
-	p.signerKP, err = ctx.StoreCtx().ResolveKey(p.kind, selected)
+	p.signerKP, err = ctx.StoreCtx().ResolveKey(selected, p.kind...)
 	return err
 }
 
 func (p *SignerParams) ForceManagedAccountKey(ctx ActionCtx, kp nkeys.KeyPair) {
-	if ctx.StoreCtx().Store.IsManaged() && p.signerKP == nil {
-		// use the account as the signer
-		p.signerKP = kp
-		// check we have a private key available
-		pk, _ := p.signerKP.PrivateKey()
-		if pk == nil {
-			// try to load it
-			pub, _ := p.signerKP.PublicKey()
-			kp, err := ctx.StoreCtx().KeyStore.GetKeyPair(pub)
-			if err == nil {
-				pk, _ := kp.PrivateKey()
-				if pk != nil {
-					p.signerKP = kp
-				}
+	p.Resolve(ctx)
+	if !ctx.StoreCtx().Store.IsManaged() {
+		return
+	}
+	if p.signerKP != nil && store.KeyPairTypeOk(nkeys.PrefixByteAccount, p.signerKP) {
+		p.signerKP = nil
+	}
+	if p.signerKP != nil {
+		return
+	}
+	// use the account as the signer
+	p.signerKP = kp
+	// check we have a private key available
+	pk, _ := p.signerKP.PrivateKey()
+	if pk == nil {
+		// try to load it
+		pub, _ := p.signerKP.PublicKey()
+		kp, err := ctx.StoreCtx().KeyStore.GetKeyPair(pub)
+		if err == nil {
+			pk, _ := kp.PrivateKey()
+			if pk != nil {
+				p.signerKP = kp
 			}
 		}
 	}

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -753,6 +754,18 @@ func (ctx *Context) ResolveKey(flagValue string, kinds ...nkeys.PrefixByte) (nke
 	if err != nil {
 		return nil, err
 	}
+	sort.Slice(kinds, func(i, j int) bool {
+		switch kind := kinds[i]; {
+		case kind == nkeys.PrefixByteAccount && kinds[j] == nkeys.PrefixByteOperator:
+			return false
+		case kind == nkeys.PrefixByteUser && kinds[j] == nkeys.PrefixByteOperator:
+			return false
+		case kind == nkeys.PrefixByteUser && kinds[j] == nkeys.PrefixByteAccount:
+			return false
+		default:
+			return true
+		}
+	})
 	for _, kind := range kinds {
 		if kp == nil {
 			var pk string

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -768,23 +768,24 @@ func (ctx *Context) ResolveKey(flagValue string, kinds ...nkeys.PrefixByte) (nke
 			if pk != "" {
 				kp, err = ctx.KeyStore.GetKeyPair(pk)
 				if err != nil {
-					return nil, err
+					continue
 				}
 			}
 			// not found
 			if kp == nil {
-				return nil, nil
+				continue
 			}
 		}
 		if !KeyPairTypeOk(kind, kp) {
 			err = fmt.Errorf("unexpected resolved keytype type")
+			continue
 		}
 		if kp != nil {
 			err = nil
 			break
 		}
 	}
-	return kp, nil
+	return kp, err
 }
 
 func (ctx *Context) PickAccount(name string) (string, error) {


### PR DESCRIPTION
Basically allow for multiple kinds to be specified.
Why this check exist is a mystery to me. Specifically because the caller also provides which keys are ok to use.

This makes it work such that in managed mode you can be set up with an operator signing key