### PR TITLE
Minor fixes to make js work when only js params are provided

### DIFF
--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -464,8 +464,6 @@ func (p *PermissionsParams) Run(perms *jwt.Permissions, ctx ActionCtx) (*store.R
 		r.AddOK("removed response permissions")
 		return r, nil
 	}
-
-	fmt.Printf("%v\n", ctx.CurrentCmd().Flag("max-responses").Value)
 
 	if ctx.CurrentCmd().Flag("max-responses").Changed || p.respMax != 0 {
 		if perms.Resp == nil {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -165,13 +165,13 @@ func ParseNumber(s string) (int64, error) {
 			return v, nil
 		}
 		if m[2] == "K" {
-			return v * 1000, nil
+			return v * 1024, nil
 		}
 		if m[2] == "M" {
-			return v * 1000000, nil
+			return v * 1024 * 1024, nil
 		}
 		if m[2] == "G" {
-			return v * 1000000000, nil
+			return v * 1024 * 1024 * 1024, nil
 		}
 	}
 	return 0, fmt.Errorf("couldn't parse number: %v", s)

--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -168,12 +168,12 @@ func TestCommon_ParseNumber(t *testing.T) {
 		{"", 0, false},
 		{"0", 0, false},
 		{"1000", 1000, false},
-		{"1K", 1000, false},
-		{"1k", 1000, false},
-		{"1M", 1000000, false},
-		{"1m", 1000000, false},
-		{"1G", 1000000000, false},
-		{"1g", 1000000000, false},
+		{"1K", 1024, false},
+		{"1k", 1024, false},
+		{"1M", 1024 * 1024, false},
+		{"1m", 1024 * 1024, false},
+		{"1G", 1024 * 1024 * 1024, false},
+		{"1g", 1024 * 1024 * 1024, false},
 		{"32a", 0, true},
 	}
 	for _, d := range tests {

--- a/cmd/editaccount.go
+++ b/cmd/editaccount.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -122,7 +122,7 @@ func (p *EditAccountParams) SetDefaults(ctx ActionCtx) error {
 		"start", "expiry", "tag", "rm-tag", "conns", "leaf-conns", "exports", "imports", "subscriptions",
 		"payload", "data", "wildcard-exports", "sk", "rm-sk", "description", "info-url", "response-ttl", "allow-pub-response",
 		"allow-pub-response", "allow-pub", "allow-pubsub", "allow-sub", "deny-pub", "deny-pubsub", "deny-sub",
-		"rm-response-perms", "rm", "max-responses") {
+		"rm-response-perms", "rm", "max-responses", "mem-storage", "disk-storage", "streams", "consumer") {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("specify an edit option")
 	}

--- a/cmd/editaccount_test.go
+++ b/cmd/editaccount_test.go
@@ -1,6 +1,6 @@
 /*
  *
- *  * Copyright 2018-2019 The NATS Authors
+ *  * Copyright 2018-2021 The NATS Authors
  *  * Licensed under the Apache License, Version 2.0 (the "License");
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
@@ -123,10 +123,10 @@ func Test_EditAccountLimits(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, int64(5), ac.Limits.Conn)
 	require.Equal(t, int64(31), ac.Limits.LeafNodeConn)
-	require.Equal(t, int64(1000*1000*10), ac.Limits.Data)
+	require.Equal(t, int64(1024*1024*10), ac.Limits.Data)
 	require.Equal(t, int64(15), ac.Limits.Exports)
 	require.Equal(t, int64(20), ac.Limits.Imports)
-	require.Equal(t, int64(1000), ac.Limits.Payload)
+	require.Equal(t, int64(1024), ac.Limits.Payload)
 	require.Equal(t, int64(30), ac.Limits.Subs)
 	require.Equal(t, int64(5), ac.Limits.Streams)
 	require.Equal(t, int64(6), ac.Limits.Consumer)


### PR DESCRIPTION
change unit converstion from 1000 to 1024 and removed printf

Signed-off-by: Matthias Hanel <mh@synadia.com>