### PR TITLE
Temporarily changed operator url back to v2

### DIFF
--- a/cmd/wellknownoperator.go
+++ b/cmd/wellknownoperator.go
@@ -36,7 +36,7 @@ var wellKnownOperators KnownOperators
 
 func defaultWellKnownOperators() KnownOperators {
 	return KnownOperators{
-		{Name: "synadia", URL: "https://www.synadia.com", AccountServerURL: "https://api.synadia.io/jwt/v2/synadia"},
+		{Name: "synadia", URL: "https://www.synadia.com", AccountServerURL: "https://api.synadia.io/jwt/v1/synadia"},
 	}
 }
 


### PR DESCRIPTION
This will disable this version of nsc in ngs

Signed-off-by: Matthias Hanel <mh@synadia.com>