### PR TITLE
Fixed issue where require strict usage was overwritten and push did fail

### DIFF
--- a/cmd/editoperator.go
+++ b/cmd/editoperator.go
@@ -109,6 +109,10 @@ func (p *EditOperatorParams) Load(ctx ActionCtx) error {
 		p.sysAcc = oc.SystemAccount
 	}
 
+	if p.reqSk == false {
+		p.reqSk = oc.StrictSigningKeyUsage
+	}
+
 	p.claim = oc
 	return nil
 }
@@ -257,12 +261,14 @@ func (p *EditOperatorParams) Run(ctx ActionCtx) (store.Status, error) {
 		r.AddOK("removed signing key %q", k)
 	}
 
-	p.claim.StrictSigningKeyUsage = p.reqSk
-	r.AddOK("strict signing key usage set to: %t", p.reqSk)
-	flags := ctx.CurrentCmd().Flags()
-	p.claim.AccountServerURL = p.asu
-	if flags.Changed("account-jwt-server-url") {
-		r.AddOK("set account jwt server url to %q", p.asu)
+	if p.claim.StrictSigningKeyUsage != p.reqSk {
+		p.claim.StrictSigningKeyUsage = p.reqSk
+		r.AddOK("strict signing key usage set to: %t", p.reqSk)
+		flags := ctx.CurrentCmd().Flags()
+		p.claim.AccountServerURL = p.asu
+		if flags.Changed("account-jwt-server-url") {
+			r.AddOK("set account jwt server url to %q", p.asu)
+		}
 	}
 
 	if p.claim.SystemAccount != p.sysAcc {

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -149,6 +149,7 @@ func getSystemAccountUser(ctx ActionCtx, sysAccName, sysAccUserName, allowSub st
 					tmpUsrPub, err := tmpUsrKp.PublicKey()
 					if err == nil {
 						tmpUsrClaim := jwt.NewUserClaims(tmpUsrPub)
+						tmpUsrClaim.IssuerAccount = op.SystemAccount
 						tmpUsrClaim.Expires = time.Now().Add(2 * time.Minute).Unix()
 						tmpUsrClaim.Name = "nsc temporary push user"
 						tmpUsrClaim.Pub.Allow.Add(allowPubs...)


### PR DESCRIPTION
push was missing issuer account

Signed-off-by: Matthias Hanel <mh@synadia.com>