### PR TITLE
`nsc pull -A` overwrites v2 operator with a v1

### DIFF
--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -227,7 +227,7 @@ func Test_AddWellKnownOperator(t *testing.T) {
 
 	// create the managed operator store
 	_, opk, okp := CreateOperatorKey(t)
-	as, _ := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, _ := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	defer as.Close()
 
 	// add an entry to well known

--- a/cmd/generateactivation_test.go
+++ b/cmd/generateactivation_test.go
@@ -229,7 +229,7 @@ func Test_GenerateActivationUsingSigningKey(t *testing.T) {
 
 func Test_InteractiveGenerateActivationPush(t *testing.T) {
 	_, _, okp := CreateOperatorKey(t)
-	as, m := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, m := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	defer as.Close()
 
 	ts := NewTestStoreWithOperator(t, "T", okp)

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -182,7 +182,7 @@ func Test_InitWellKnownV1Operator(t *testing.T) {
 
 	_, _, okp := CreateOperatorKey(t)
 	// run a jwt account server
-	as, _ := RunTestAccountServerWithOperatorKP(t, okp, 1)
+	as, _ := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 1})
 	defer as.Close()
 
 	// add an entry to well known

--- a/cmd/migrate_test.go
+++ b/cmd/migrate_test.go
@@ -94,7 +94,7 @@ func Test_MigrateSingleInteractive(t *testing.T) {
 
 func Test_MigrateManaged(t *testing.T) {
 	_, opk, okp := CreateOperatorKey(t)
-	as, m := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, m := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	defer as.Close()
 
 	// create the managed operator store

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -32,7 +32,7 @@ import (
 
 func Test_SyncOK(t *testing.T) {
 	_, _, okp := CreateOperatorKey(t)
-	as, m := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, m := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	defer as.Close()
 
 	ts := NewTestStoreWithOperator(t, "T", okp)
@@ -56,7 +56,7 @@ func Test_SyncOK(t *testing.T) {
 
 func Test_SyncNoURL(t *testing.T) {
 	_, _, okp := CreateOperatorKey(t)
-	as, m := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, m := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	ts := NewTestStoreWithOperatorJWT(t, string(m["operator"]))
 	ts.AddAccount(t, "A")
 	as.Close()
@@ -104,7 +104,7 @@ func Test_SyncManaged(t *testing.T) {
 
 func Test_SyncManualServer(t *testing.T) {
 	_, _, okp := CreateOperatorKey(t)
-	as, m := RunTestAccountServerWithOperatorKP(t, okp, 2)
+	as, m := RunTestAccountServerWithOperatorKP(t, okp, TasOpts{Vers: 2})
 	defer as.Close()
 
 	// remove the account server

--- a/cmd/store/store.go
+++ b/cmd/store/store.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -342,6 +342,9 @@ func PullAccount(u string) (Status, error) {
 	r, err := c.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("error pulling %q: %v", u, err)
+	}
+	if r.StatusCode > 299 {
+		return nil, fmt.Errorf("error pulling %q: %d", u, r.StatusCode)
 	}
 	defer r.Body.Close()
 	var buf bytes.Buffer

--- a/cmd/wellknownoperator.go
+++ b/cmd/wellknownoperator.go
@@ -36,7 +36,7 @@ var wellKnownOperators KnownOperators
 
 func defaultWellKnownOperators() KnownOperators {
 	return KnownOperators{
-		{Name: "synadia", URL: "https://www.synadia.com", AccountServerURL: "https://api.synadia.io/jwt/v1/synadia"},
+		{Name: "synadia", URL: "https://www.synadia.com", AccountServerURL: "https://api.synadia.io/jwt/v2/synadia"},
 	}
 }
 


### PR DESCRIPTION
made operator pulls check v2 before v1, this is just a temporary solution, as the correct thing is to change the account server to handle a query string parameter to determine if the client is looking for a v2 JWT.
FIX #388