### PR TITLE
Installer: Unbreak Alpine in Docker

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -204,6 +204,9 @@ normalized_arch() {
 
   local narch
   narch="$(uname -p)"
+  # We see inside Alpine Linux inside Docker that uname -p can fail with unknown
+  # but the arch command can work.
+  if [ "$narch" = "unknown" ]; then narch="$(arch)"; fi
   case "$narch" in
     (x86_64) narch="amd64" ;;
     (amd64) true ;;
@@ -219,7 +222,13 @@ normalized_arch() {
 }
 
 zip_filename_per_os() {
-  printf '%s\n' "nsc-$(normalized_ostype)-$(normalized_arch).zip"
+  # We break these out into a separate variable instead of passing directly
+  # to printf, so that if there's a failure in normalization then the printf
+  # won't swallow the exit status of the $(...) subshell and will instead
+  # abort correctly.
+  local zipname
+  zipname="nsc-$(normalized_ostype)-$(normalized_arch).zip" || exit $?
+  printf '%s\n' "${zipname}"
 }
 
 exe_filename_per_os() {


### PR DESCRIPTION
The `uname -p` command can return `unknown`, even while `arch` returns a real value.  Even though uname is more widely guaranteed to be present.  So, handle "unknown" as a special case and try arch(1).  If calling arch fails then we'll abort and we're no worse off than we were with an "unknown" value.

Make sure that errors inside command substitution sub-shells propagate properly out, by splitting a printf invocation to use an intermediate variable setting first; this way, printf(1) won't swallow the $? and mask it, and we can force an exit if the sub-shell failed.

This repairs an installability regression introduced with the switch to multi-arch support (for handling arm64); prior to that, we assumed amd64 always.