### PR TITLE
Account token position

### DIFF
--- a/cmd/addexport.go
+++ b/cmd/addexport.go
@@ -53,9 +53,7 @@ func createAddExportCmd() *cobra.Command {
 	params.AccountContextParams.BindFlags(cmd)
 
 	cmd.Flags().UintVarP(&params.accountTokenPosition, "account-token-position", "", 0, "subject token position where account is expected (public exports only)")
-	cmd.Flag("account-token-position").Hidden = true
 	cmd.Flags().BoolVarP(&params.advertise, "advertise", "", false, "advertise export")
-	cmd.Flag("advertise").Hidden = true
 
 	return cmd
 }

--- a/cmd/addexport.go
+++ b/cmd/addexport.go
@@ -54,6 +54,7 @@ func createAddExportCmd() *cobra.Command {
 
 	cmd.Flags().UintVarP(&params.accountTokenPosition, "account-token-position", "", 0, "subject token position where account is expected (public exports only)")
 	cmd.Flags().BoolVarP(&params.advertise, "advertise", "", false, "advertise export")
+	cmd.Flag("advertise").Hidden = true
 
 	return cmd
 }

--- a/cmd/addexport_test.go
+++ b/cmd/addexport_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -44,6 +44,21 @@ func Test_AddExport(t *testing.T) {
 		{createAddExportCmd(), []string{"add", "export", "--subject", "th.2", "--response-threshold", "1whatever"}, nil, []string{`time: unknown unit`}, true},
 	}
 
+	tests.Run(t, "root", "add")
+}
+
+func Test_AddPublicExport(t *testing.T) {
+	ts := NewTestStore(t, "add_export")
+	defer ts.Done(t)
+
+	ts.AddAccount(t, "A")
+	tests := CmdTests{
+		{createAddExportCmd(), []string{"add", "export", "--private=false", "--subject", "hello"}, nil, []string{"added public stream export \"hello\""}, false},
+		{createAddExportCmd(), []string{"add", "export", "--private=false", "--subject", "hello", "--account-token-position", "1"}, nil, []string{"Account Token Position can only be used with wildcard subjects"}, true},
+		{createAddExportCmd(), []string{"add", "export", "--private=false", "--subject", "*.hello", "--account-token-position", "2"}, nil, []string{"Account Token Position 2 matches 'hello' but must match a *"}, true},
+		{createAddExportCmd(), []string{"add", "export", "--private=false", "--subject", "*.hello", "--account-token-position", "3"}, nil, []string{"Account Token Position 3 exceeds length of subject"}, true},
+		{createAddExportCmd(), []string{"add", "export", "--private=false", "--subject", "*.hello", "--account-token-position", "1"}, nil, []string{" added public stream export \"*.hello\""}, false},
+	}
 	tests.Run(t, "root", "add")
 }
 

--- a/cmd/addimport.go
+++ b/cmd/addimport.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2021 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -45,7 +45,7 @@ func createAddImportCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&params.local, "local-subject", "s", "", "local subject")
 	params.srcAccount.BindFlags("src-account", "", nkeys.PrefixByteAccount, cmd)
 	cmd.Flags().StringVarP(&params.remote, "remote-subject", "", "", "remote subject (only public imports)")
-	cmd.Flags().BoolVarP(&params.service, "service", "", false, "service (only public imports)")
+	cmd.Flags().BoolVarP(&params.service, "service", "", false, "service")
 	cmd.Flags().BoolVarP(&params.share, "share", "", false, "share data when tracking latency (service only)")
 	params.AccountContextParams.BindFlags(cmd)
 
@@ -248,7 +248,7 @@ func (p *AddImportParams) generateToken(ctx ActionCtx, c *AccountExportChoice) e
 	return p.initFromActivation(ctx)
 }
 
-func (p *AddImportParams) addManualExport(ctx ActionCtx) error {
+func (p *AddImportParams) addManualExport(_ ActionCtx) error {
 	var err error
 	p.public, err = cli.Confirm("is the export public?", true)
 	if err != nil {
@@ -341,7 +341,7 @@ func (p *AddImportParams) Load(ctx ActionCtx) error {
 	return nil
 }
 
-func (p *AddImportParams) initFromActivation(ctx ActionCtx) error {
+func (p *AddImportParams) initFromActivation(_ ActionCtx) error {
 	var err error
 	if p.token == nil {
 		p.token, err = p.loadImport()


### PR DESCRIPTION
[FIX] removed misleading flag help for service as only supported on public imports

[FEAT] Added support for `--account-token-position`
[FEAT] Added support for `--advertise` (hidden) for public exports.

The `--account-token-position` allows public exports from an account to be constrained to
a subject that is clamped to the account. The NATS server will ensure that only an
importing account sporting a matching public key in the specified wildcard token can
access the service/stream. This removes the burden of generating a token for subjects
that follow such a pattern on system-wide services