### PR TITLE
[fixed] export/import type mismatch in diagram generation

### DIFF
--- a/cmd/generatediagram.go
+++ b/cmd/generatediagram.go
@@ -223,7 +223,7 @@ skinparam interface {
 			impAcc, foundExporter := accBySubj[i.Account]
 			if foundExporter {
 				for _, e := range impAcc.Exports {
-					if jwt.Subject(remote).IsContainedIn(e.Subject) {
+					if i.Type == e.Type && jwt.Subject(remote).IsContainedIn(e.Subject) {
 						matchingExport = e
 						foundExport = true
 						break


### PR DESCRIPTION
now shows as not connected

Signed-off-by: Matthias Hanel <mh@synadia.com>