### PR TITLE
[added] support for evn vars  NATS_KEY & NATS_CERT for verify=true

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -36,6 +36,8 @@ const NscHomeEnv = "NSC_HOME"
 const NscCwdOnlyEnv = "NSC_CWD_ONLY"
 const NscNoGitIgnoreEnv = "NSC_NO_GIT_IGNORE"
 const NscRootCasNatsEnv = "NATS_CA"
+const NscTlsKeyNatsEnv = "NATS_KEY"
+const NscTlsCertNatsEnv = "NATS_CERT"
 
 type ToolConfig struct {
 	ContextConfig
@@ -49,6 +51,9 @@ var config ToolConfig
 var toolHome string
 var homeEnv string
 var rootCAsNats nats.Option // Will be skipped, when nil and passed to a connection
+var tlsKeyNats nats.Option // Will be skipped, when nil and passed to a connection
+var tlsCertNats nats.Option // Will be skipped, when nil and passed to a connection
+
 var rootCAsFile string
 
 func SetToolName(name string) {

--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -51,7 +51,7 @@ var config ToolConfig
 var toolHome string
 var homeEnv string
 var rootCAsNats nats.Option // Will be skipped, when nil and passed to a connection
-var tlsKeyNats nats.Option // Will be skipped, when nil and passed to a connection
+var tlsKeyNats nats.Option  // Will be skipped, when nil and passed to a connection
 var tlsCertNats nats.Option // Will be skipped, when nil and passed to a connection
 
 var rootCAsFile string

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -100,6 +100,10 @@ func (p *SetContextParams) PrintEnv(cmd *cobra.Command) {
 	table.AddRow("$"+NscRootCasNatsEnv, envSet(NscRootCasNatsEnv),
 		"If set, root CAs in the referenced file will be used for nats connections")
 	table.AddRow("", "", "If not set, will default to the system trust store")
+	table.AddRow("$"+NscTlsKeyNatsEnv, envSet(NscTlsKeyNatsEnv),
+		"If set, the tls key in the referenced file will be used for nats connections")
+	table.AddRow("$"+NscTlsCertNatsEnv, envSet(NscTlsCertNatsEnv),
+		"If set, the tls cert in the referenced file will be used for nats connections")
 	table.AddSeparator()
 	r := conf.StoreRoot
 	if r == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -199,6 +199,11 @@ func SetEnvOptions() {
 		rootCAsFile = strings.TrimSpace(f)
 		rootCAsNats = nats.RootCAs(rootCAsFile)
 	}
+	key, okKey := os.LookupEnv(NscTlsKeyNatsEnv)
+	cert, okCert := os.LookupEnv(NscTlsCertNatsEnv)
+	if okKey || okCert {
+		tlsKeyNats = nats.ClientCert(cert, key)
+	}
 }
 
 func init() {

--- a/cmd/tool.go
+++ b/cmd/tool.go
@@ -52,6 +52,8 @@ func createDefaultToolOptions(name string, ctx ActionCtx, o ...nats.Option) []na
 	opts := []nats.Option{nats.Name(name)}
 	opts = append(opts, nats.Timeout(connectTimeout))
 	opts = append(opts, rootCAsNats)
+	opts = append(opts, tlsKeyNats)
+	opts = append(opts, tlsCertNats)
 	opts = append(opts, nats.ReconnectWait(reconnectDelay))
 	opts = append(opts, nats.MaxReconnects(int(totalWait/reconnectDelay)))
 	opts = append(opts, nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {


### PR DESCRIPTION
This allows to specify key and cert for nats connection connecting to a
server requiring client certs.

Fixes #408

Signed-off-by: Matthias Hanel <mh@synadia.com>