### PR TITLE
DOCS: conn-type flag description

### DIFF
--- a/cmd/edituser.go
+++ b/cmd/edituser.go
@@ -350,7 +350,7 @@ func (p *UserPermissionLimits) BindFlags(cmd *cobra.Command) {
 	cmd.Flags().VarP(&p.locale, "locale", "", "set the locale with which time values are interpreted")
 	cmd.Flags().StringSliceVarP(&p.src, "source-network", "", nil, "add source network for connection - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringSliceVarP(&p.rmSrc, "rm-source-network", "", nil, "remove source network for connection - comma separated list or option can be specified multiple times")
-	cmd.Flags().StringSliceVarP(&p.connTypes, "conn-type", "", nil, fmt.Sprintf("add connection types: %s %s %s %s - comma separated list or option can be specified multiple times",
+	cmd.Flags().StringSliceVarP(&p.connTypes, "conn-type", "", nil, fmt.Sprintf("define allowed connection types: %s %s %s %s - comma separated list or option can be specified multiple times",
 		jwt.ConnectionTypeLeafnode, jwt.ConnectionTypeMqtt, jwt.ConnectionTypeStandard, jwt.ConnectionTypeWebsocket))
 	cmd.Flags().StringSliceVarP(&p.rmConnTypes, "rm-conn-type", "", nil, "remove connection types - comma separated list or option can be specified multiple times")
 	cmd.Flags().Int64VarP(&p.maxSubs, "subs", "", -1, "set maximum number of subscriptions (-1 is unlimited)")


### PR DESCRIPTION
The flag "--conn-type" defines the allowed connections. If you define --conn-type MQTT, the user will **exclusively** have access via MQTT.
This bahaviour is not properly stated / documented. Therefore I suggest to adjust the flag description.
The feature description and behaviour was introduced here: https://github.com/nats-io/jwt/pull/97