### PR TITLE
fixed scoped signing key re-signing issue

### DIFF
--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -285,10 +285,8 @@ func checkUserForScope(ctx ActionCtx, accountName string, signerKP nkeys.KeyPair
 		return err
 	}
 	if s, ok := ac.SigningKeys.GetScope(pk); ok && s != nil {
-		if uc.Issuer == "" {
-			// set issuer as this is commonly set during encoding but is required next
-			uc.Issuer = pk
-		}
+		// set issuer as this is commonly set during encoding but is required next
+		uc.Issuer = pk
 		if err := s.ValidateScopedSigner(uc); err != nil {
 			return err
 		}


### PR DESCRIPTION
Because the user aleady had an issuer, you could never re-sign with a
different key.

Signed-off-by: Matthias Hanel <mh@synadia.com>