### PR TITLE
added code to keep plantuml from rendering * as O

### DIFF
--- a/cmd/generatediagram.go
+++ b/cmd/generatediagram.go
@@ -181,6 +181,13 @@ skinparam interface {
 		}
 		bldrPrntf("end note")
 	}
+	escapeSubjectLabel := func(sub string) string {
+		// * is special notation in plantuml. (escape by adding a space)
+		if strings.HasPrefix(sub, "*") {
+			return fmt.Sprintf(" %s", sub)
+		}
+		return sub
+	}
 	bldrPrntf(`title Component Diagram of Accounts - Operator %s`, op.Name)
 	accs, _ := s.ListSubContainers(store.Accounts)
 	accBySubj := make(map[string]*jwt.AccountClaims)
@@ -198,7 +205,7 @@ skinparam interface {
 		for _, e := range ac.Exports {
 			eId := expId(ac.Subject, e)
 			bldrPrntf(`interface "%s" << %s %s >> as %s`, expName(e), accessMod(e), expType(e), eId)
-			bldrPrntf(`%s -- %s : ""%s""`, expId(ac.Subject, e), ac.Subject, e.Subject)
+			bldrPrntf(`%s -- %s : ""%s"""`, expId(ac.Subject, e), ac.Subject, escapeSubjectLabel(string(e.Subject)))
 			addNote(eId, e.Info)
 
 			vr := jwt.ValidationResults{}
@@ -235,9 +242,9 @@ skinparam interface {
 				bldrPrntf(`interface " " << not-found %s %s >> as %s`, accessMod(matchingExport), expType(matchingExport), id)
 			}
 			if local != remote {
-				bldrPrntf(`%s "%s%s" ..> %s : "%s"`, ac.Subject, rename, local, id, remote)
+				bldrPrntf(`%s "%s%s" ..> %s : "%s"`, ac.Subject, rename, local, id, escapeSubjectLabel(remote))
 			} else {
-				bldrPrntf(`%s ..> %s : "%s"`, ac.Subject, id, remote)
+				bldrPrntf(`%s ..> %s : "%s"`, ac.Subject, id, escapeSubjectLabel(remote))
 			}
 			vr := jwt.ValidationResults{}
 			i.Validate(ac.Subject, &vr)


### PR DESCRIPTION
`*` is some sort of special relationship notation for plantuml

Signed-off-by: Matthias Hanel <mh@synadia.com>

without change 
![Screen Shot 2021-12-10 at 8 33 58 PM](https://user-images.githubusercontent.com/19881388/145659240-818953c1-0f71-4170-afe2-46a943a07724.png)

with change
![Screen Shot 2021-12-10 at 8 34 52 PM](https://user-images.githubusercontent.com/19881388/145659245-6bdd09e5-8285-4e92-b5e8-cb9dfd6066d3.png)

