### PR TITLE
[FIX] added `--rm-account-jwt-server-url`

### DIFF
--- a/cmd/generateprofile.go
+++ b/cmd/generateprofile.go
@@ -71,7 +71,7 @@ user, account, operator, If no prefix (user/account/operator is provided,
 it targets the last object in the configuration path)
 		`,
 
-		Args: MaxArgs(1),
+		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			us := args[0]
 			u, err := ParseNscURL(us)


### PR DESCRIPTION
[FIX] added `--rm-account-jwt-server-url` to remove the account server url from the operator JWT.

FIX #446