### PR TITLE
[FIX] handling of account names instead of public keys

### DIFF
--- a/cmd/addimport.go
+++ b/cmd/addimport.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -95,11 +95,12 @@ func (p *AddImportParams) SetDefaults(ctx ActionCtx) error {
 			return errors.New("public imports require src-account, remote-subject")
 		}
 	}
-
 	if err := p.AccountContextParams.SetDefaults(ctx); err != nil {
 		return err
 	}
-
+	if err := p.srcAccount.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 
 	if p.name == "" {

--- a/cmd/addimport_test.go
+++ b/cmd/addimport_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -54,7 +54,6 @@ func Test_AddImportNoDefaultAccount(t *testing.T) {
 
 	ts.AddAccount(t, "A")
 	ts.AddAccount(t, "B")
-
 }
 
 func Test_AddImportSelfImportsRejected(t *testing.T) {

--- a/cmd/generateactivation.go
+++ b/cmd/generateactivation.go
@@ -1,18 +1,16 @@
 /*
+ * Copyright 2018-2022 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  * Copyright 2018-2019 The NATS Authors
- *  * Licensed under the Apache License, Version 2.0 (the "License");
- *  * you may not use this file except in compliance with the License.
- *  * You may obtain a copy of the License at
- *  *
- *  * http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing, software
- *  * distributed under the License is distributed on an "AS IS" BASIS,
- *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  * See the License for the specific language governing permissions and
- *  * limitations under the License.
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package cmd
@@ -72,6 +70,9 @@ type GenerateActivationParams struct {
 
 func (p *GenerateActivationParams) SetDefaults(ctx ActionCtx) error {
 	p.AccountContextParams.SetDefaults(ctx)
+	if err := p.accountKey.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteAccount, false, ctx)
 	return nil
 }

--- a/cmd/revoke_clearactivation.go
+++ b/cmd/revoke_clearactivation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -66,6 +66,9 @@ type RevokeClearActivationParams struct {
 func (p *RevokeClearActivationParams) SetDefaults(ctx ActionCtx) error {
 	p.accountKey.AllowWildcard = true
 	p.AccountContextParams.SetDefaults(ctx)
+	if err := p.accountKey.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 	return nil
 }

--- a/cmd/revokeactivation.go
+++ b/cmd/revokeactivation.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -70,6 +70,9 @@ type RevokeActivationParams struct {
 func (p *RevokeActivationParams) SetDefaults(ctx ActionCtx) error {
 	p.accountKey.AllowWildcard = true
 	p.AccountContextParams.SetDefaults(ctx)
+	if err := p.accountKey.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 	return nil
 }

--- a/cmd/revokeclearuser.go
+++ b/cmd/revokeclearuser.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -63,6 +63,9 @@ func (p *ClearRevokeUserParams) SetDefaults(ctx ActionCtx) error {
 	}
 	p.userKey.AllowWildcard = true
 	p.AccountContextParams.SetDefaults(ctx)
+	if err := p.userKey.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 	return nil
 }

--- a/cmd/revokeuser.go
+++ b/cmd/revokeuser.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -68,6 +68,9 @@ func (p *RevokeUserParams) SetDefaults(ctx ActionCtx) error {
 	}
 	p.userKey.AllowWildcard = true
 	p.AccountContextParams.SetDefaults(ctx)
+	if err := p.userKey.SetDefaults(ctx); err != nil {
+		return err
+	}
 	p.SignerParams.SetDefaults(nkeys.PrefixByteOperator, true, ctx)
 	return nil
 }


### PR DESCRIPTION
PubKeyParams had functionality that initialized when the command flags were preparing for a command invocation. If the context of the store was not properly set, it failed. The fix handles the initialization of the flags during the command execution by providing the context for the command. Also, functionality to handle usernames instead of keys would wasn't handled.

FIX #454