### PR TITLE
show better error when adding operator w/ bad url

### DIFF
--- a/cmd/addoperator.go
+++ b/cmd/addoperator.go
@@ -150,26 +150,17 @@ func (p *AddOperatorParams) Load(ctx ActionCtx) error {
 	}
 	if p.jwtPath != "" {
 		var err error
-		var urlLoadingErr error
 		var data []byte
 		loadedFromURL := false
 
-		// If we think the path is a url, try loading it as such.
-		// If that doesn't work, still try it as a path.
-		// If THAT doesn't work, and we have an error from the url reading step,
-		// that's the one we probably care about.
 		if IsURL(p.jwtPath) {
 			loadedFromURL = true
-			data, urlLoadingErr = LoadFromURL(p.jwtPath)
-		}
-		if data == nil {
+			data, err = LoadFromURL(p.jwtPath)
+		} else {
 			data, err = Read(p.jwtPath)
-			if err != nil {
-				if urlLoadingErr != nil {
-					err = urlLoadingErr
-				}
-				return fmt.Errorf("error reading %#q: %v", p.jwtPath, err)
-			}
+		}
+		if err != nil {
+			return fmt.Errorf("error reading %#q: %v", p.jwtPath, err)
 		}
 
 		token, err := jwt.ParseDecoratedJWT(data)

--- a/cmd/addoperator.go
+++ b/cmd/addoperator.go
@@ -150,15 +150,24 @@ func (p *AddOperatorParams) Load(ctx ActionCtx) error {
 	}
 	if p.jwtPath != "" {
 		var err error
+		var urlLoadingErr error
 		var data []byte
 		loadedFromURL := false
+
+		// If we think the path is a url, try loading it as such.
+		// If that doesn't work, still try it as a path.
+		// If THAT doesn't work, and we have an error from the url reading step,
+		// that's the one we probably care about.
 		if IsURL(p.jwtPath) {
 			loadedFromURL = true
-			data, _ = LoadFromURL(p.jwtPath)
+			data, urlLoadingErr = LoadFromURL(p.jwtPath)
 		}
 		if data == nil {
 			data, err = Read(p.jwtPath)
 			if err != nil {
+				if urlLoadingErr != nil {
+					err = urlLoadingErr
+				}
 				return fmt.Errorf("error reading %#q: %v", p.jwtPath, err)
 			}
 		}


### PR DESCRIPTION
I think this should address https://github.com/nats-io/nsc/issues/429

Instead of throwing away the error from fetching the path as a url, hold on to it and if fetching as path also fails, return the first error.