### PR TITLE
Add version info to the packages name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,7 @@ dist: build
 archives:
   - id: "nsc.zip"
     wrap_in_directory: false
-    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    name_template: '{{ .ProjectName }}-{{ .Tag }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format: zip
     files:
       - none*


### PR DESCRIPTION
This PR add version information in the packages' name

`nsc-linux-amd64.zip` -->  `nsc-2.6.1-linux-amd64.zip` 

Closes: #471