### PR TITLE
Add operator name flag to load

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -65,6 +65,7 @@ func createLoadCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&params.accountServerURL, "url", "", "", "URL of the account server")
 	cmd.Flags().StringVarP(&params.accountSeed, "seed", "", "", "Seed of the account used to create users")
 	cmd.Flags().StringVarP(&params.username, "user", "", "default", "Default username")
+	cmd.Flags().StringVarP(&params.operatorName, "operator", "", "", "Name used for the operator context")
 	return cmd
 }
 


### PR DESCRIPTION
This allows choosing the name of the operator in created context:

```sh
nsc load --operator synadia-dev --url https://$url/jwt/v1/operator --user example --seed SA...
```

Signed-off-by: Waldemar Quevedo <wally@nats.io>