### PR TITLE
releng: remove: ssh; signing keys from disappearing disk

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,9 @@ on:
       # Obviously if we change that, we'll still have an installed base with the old logic so won't be able to start using the new naming for some time.
       # We match on v* for consistency and with an eye to the future.
       # To avoid random experimental tags creating releases, we use ${major}.* and ${nextmajor}.* for the rules which will actually match.
+      # We allow 0.0.X for debugging of release engineering processes, where it won't create a new release.
       - 'v*'
+      - '0.0.*'
       - '2.*'
       - '3.*'
 
@@ -46,21 +48,10 @@ jobs:
         uses: sigstore/cosign-installer@main
         # This is used inside goreleaser, not as a separate step in this file
 
-      - name: Basic Go integrity checks
+      - name: Basic integrity checks
         # TODO: If we switch from vendor to modules, consider a Retracted check here
         run: |
           go vet ./...
-
-      - name: Expose signing keys to goreleaser
-        # Ideally we'd do this after the compilation, to reduce lifetime of
-        # visibility, but that's not goreleaser's model: it's all-or-nothing.
-        # We rely upon /tmp in the builders being private.
-        run: |
-          touch /tmp/cosign.key /tmp/ssh-release-sign
-          chmod 0600 /tmp/cosign.key /tmp/ssh-release-sign
-          printf '%s\n' "${{ secrets.RELEASE_SIGNING_KEY_COSIGN }}" >> /tmp/cosign.key
-          printf '%s\n' "${{ secrets.RELEASE_SIGNING_KEY_SSH }}" >> /tmp/ssh-release-sign
-          ls -ld /tmp/cosign.key /tmp/ssh-release-sign
 
       - name: Run GoReleaser
         id: goreleaser
@@ -72,5 +63,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
+          SIGNING_KEY_COSIGN: ${{ secrets.RELEASE_SIGNING_KEY_COSIGN }}
+          SIGNING_KEY_SSH: ${{ secrets.RELEASE_SIGNING_KEY_SSH }}
           COSIGN_PASSWORD: ""
-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,17 +76,18 @@ snapshot:
 
 signs:
   - id: cosign
-    cmd: cosign
-    args: ["sign-blob", "--key=/tmp/cosign.key", "--output-signature=${signature}", "${artifact}"]
+    cmd: "./release/sign-cosign"
+    args: ["${artifact}", "${signature}"]
     signature: "${artifact}.cosign.sig"
     artifacts: checksum
     # We pass COSIGN_PASSWORD from GH secret through env, and cosign(1) picks up
     # that automatically, so we don't need to pass the password on stdin.
-  - id: ssh
-    cmd: "./release/sign-ssh"
-    args: ["/tmp/ssh-release-sign", "${artifact}", "${signature}"]
-    signature: "${artifact}.ssh.sig"
-    artifacts: checksum
+# Disabled pending Ubuntu 22.04:
+# - id: ssh
+#   cmd: "./release/sign-ssh"
+#   args: ["${artifact}", "${signature}"]
+#   signature: "${artifact}.ssh.sig"
+#   artifacts: checksum
 
 
 brews:

--- a/release/sign-cosign
+++ b/release/sign-cosign
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# The accepted cosign invocation pattern for using an environment variable as
+# the key is to use <( ... ) substitution, which is not POSIX sh,
+# so we use bash.
+#
+# If <https://github.com/sigstore/cosign/issues/1776> is resolved then the need
+# for this wrapper goes away.
+
+progname="$(dirname "$0")"
+stderr() { printf >&2 '%s: %s\n' "$progname" "$*"; }
+die_n() { e="$1"; shift; stderr "$@"; exit "$e"; }
+EX_USAGE=64
+
+[[ -n "${SIGNING_KEY_COSIGN:-}" ]] || die_n $EX_USAGE 'missing env var SIGNING_KEY_COSIGN'
+
+artifact="${1:?need a file to sign}"
+signature="${2:?need a file to create}"
+
+: "${COSIGN_PASSWORD:=}"
+export COSIGN_PASSWORD
+
+[[ -f "$artifact" ]] || die_n $EX_USAGE "missing input file: ${artifact@Q}"
+if [[ -f "$signature" ]]; then
+	stderr "deleting pre-existing signature file: ${signature@Q}"
+	rm -f -- "$signature"
+fi
+
+cosign sign-blob \
+	--key <( printf '%s\n' "$SIGNING_KEY_COSIGN" ) \
+	--output-signature "$signature" \
+	"$artifact"

--- a/release/sign-ssh
+++ b/release/sign-ssh
@@ -1,10 +1,33 @@
-#!/bin/sh -eu
+#!/usr/bin/env bash
+set -euo pipefail
 #
 # This file exists to fix the impedance mismatch between cosign running one
 # command and ssh-keygen using either a fixed conflicting filename or stdout.
+#
+# This is failing badly on Ubuntu 20.04 stock ssh-keygen (8.2), so I'm leaving
+# this release tool in, but removing the invocation.  22.04 should be out soon
+# so we will try again with that.  As long as signature _verification_ works
+# portably, we still want a "tool everyone has" signature verifier.
 
-keyfile="${1:?need an SSH private key}"
-artifact="${2:?need a file to sign}"
-signature="${3:?need a file to create}"
+progname="$(dirname "$0")"
+stderr() { printf >&2 '%s: %s\n' "$progname" "$*"; }
+die_n() { e="$1"; shift; stderr "$@"; exit "$e"; }
+EX_USAGE=64
 
-exec ssh-keygen -Y sign -n file -f "$keyfile" < "$artifact" > "$signature"
+[[ -n "${SIGNING_KEY_SSH:-}" ]] || die_n $EX_USAGE 'missing env var SIGNING_KEY_SSH'
+
+artifact="${1:?need a file to sign}"
+signature="${2:?need a file to create}"
+
+# ssh-keygen won't read the key from a pipe
+
+keyfile="$(mktemp)"
+printf >> "$keyfile" '%s\n' "$SIGNING_KEY_SSH"
+
+set +e
+ssh-keygen -Y sign -n file \
+	-f "$keyfile" \
+	< "$artifact" > "$signature"
+ev=$?
+rm -f "$keyfile"
+exit $ev


### PR DESCRIPTION
Wrap both signing commands in consistent wrapper shims.  These will expose the signing keys in the right ways to the commands.

Trigger release flow for 0.0.x too, for testing.

Temporarily stop using the ssh signer, because of bugs in the signing flow with older OpenSSH, fixed in more recent releases; we'll try again with 22.04.

---

There's still one issue which I think will prevent full signing inside GitHub: the automatic brew formula update.  What do we want to do about that?