### PR TITLE
Lock goreleaser version, adjust name templates; license

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,10 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           distribution: goreleaser-pro
-          version: latest
+          # We have seen a couple of bugs, so are locking this for now.
+          # v1.8.3-pro fixes some issues in brew architecture image variants
+          # which led to <https://github.com/nats-io/homebrew-nats-tools/issues/9>
+          version: v1.8.3-pro
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,7 +63,9 @@ dist: build
 archives:
   - id: "nsc.zip"
     wrap_in_directory: false
-    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    # documented default (2022-04-20):
+    # '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
     format: zip
     files:
       - none*
@@ -96,9 +98,10 @@ brews:
     tap:
       owner: nats-io
       name: homebrew-nats-tools
-    url_template: "https://github.com/nats-io/nsc/releases/download/{{ .Tag }}/nsc-{{ .Os }}-{{ .Arch }}.zip"
+    url_template: 'https://github.com/nats-io/nsc/releases/download/{{ .Tag }}/nsc-{{ .Os }}-{{ .Arch }}{{ with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}.zip'
     homepage: "https://github.com/nats-io/nsc"
     description: "A tool for creating NATS account and user access configurations"
+    license: "Apache-2.0"
     skip_upload: false
     test: |
       system "#{bin}/nsc --version"


### PR DESCRIPTION
In debugging missing architectures from the generated brew data, it eventually was "goreleaser bug, fixed in newer patchlevel release".

We had one bug in that the archive names for 32-bit ARM would have a vN suffix but the specification for brew did not include that.  Fixed, and include a reference to the default and just leave all the architecture finangling in-place in both.

nsc is under the Apache-2.0 license (SPDX identifier), so tell Brew that.
