### PR TITLE
Don't ask GitHub Actions to upload brew formula

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,3 +69,9 @@ jobs:
           SIGNING_KEY_COSIGN: ${{ secrets.RELEASE_SIGNING_KEY_COSIGN }}
           SIGNING_KEY_SSH: ${{ secrets.RELEASE_SIGNING_KEY_SSH }}
           COSIGN_PASSWORD: ""
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: homebrew-formula-nsc.rb
+          path: build/nsc.rb

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -102,7 +102,9 @@ brews:
     homepage: "https://github.com/nats-io/nsc"
     description: "A tool for creating NATS account and user access configurations"
     license: "Apache-2.0"
-    skip_upload: false
+    # Cross-repo upload currently requires that $GITHUB_ACTION be a PAT which has some undesirable security characteristics.
+    # We are instead registering this as a build artifact, so that the file is available for a manual PR of nsc.rb in the tap.
+    skip_upload: true
     test: |
       system "#{bin}/nsc --version"
     install: |


### PR DESCRIPTION
Cross-repo action access is an "interesting" security proposition right now.  Instead, skip the upload but register the formula as a build artifact, where it can be found to make a manual fix to the homebrew tap repo.

It's the least-bad solution.

WARNING 1: this is an _untested_ fix.  It looks sane to me.
WARNING 2: I'm about to head out the door for a long weekend vacation.  Merge or not as you see fit, to balance risk of "needing a release" vs "debugging if things go wrong", but since things are broken in GHActions right now without this, I don't think this will make things _worse_.

:speak_no_evil: famous last words.
