### PR TITLE
[FIX] added a validation check on the user context params

### DIFF
--- a/cmd/pubtool.go
+++ b/cmd/pubtool.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -88,6 +88,10 @@ func (p *PubParams) PostInteractive(ctx ActionCtx) error {
 
 func (p *PubParams) Validate(ctx ActionCtx) error {
 	if err := p.AccountContextParams.Validate(ctx); err != nil {
+		return err
+	}
+
+	if err := p.UserContextParams.Validate(ctx); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Added a missing validation check for the user context params. 
```
go run main.go pub -a A foo bar
Error: a user is required
Usage:
  nsc pub [flags]
```

FIXES #491 
