### PR TITLE
Report permission errors while using tools

### DIFF
--- a/cmd/pubtool.go
+++ b/cmd/pubtool.go
@@ -128,6 +128,9 @@ func (p *PubParams) Run(ctx ActionCtx) (store.Status, error) {
 	if err := nc.Flush(); err != nil {
 		return nil, err
 	}
+	if err := nc.LastError(); err != nil {
+		return nil, err
+	}
 
 	ctx.CurrentCmd().Printf("Published [%s] : %q\n", subj, payload)
 

--- a/cmd/replytool.go
+++ b/cmd/replytool.go
@@ -150,6 +150,9 @@ func (p *RepParams) Run(ctx ActionCtx) (store.Status, error) {
 	if err := nc.Flush(); err != nil {
 		return nil, err
 	}
+	if err := nc.LastError(); err != nil {
+		return nil, err
+	}
 
 	i := 0
 	for {

--- a/cmd/subtool.go
+++ b/cmd/subtool.go
@@ -149,6 +149,9 @@ func (p *SubParams) Run(ctx ActionCtx) (store.Status, error) {
 	if err := nc.Flush(); err != nil {
 		return nil, err
 	}
+	if err := nc.LastError(); err != nil {
+		return nil, err
+	}
 
 	var seed string
 	if encryptFlag {


### PR DESCRIPTION
### Before change
Currently, permission violations are ignored.

The `pub` command returns a success exit code, even though there is a permission violation.
```
$ nsc tool pub --nats nats://foo:foo@localhost:4222 bad hi
Published [bad] : "hi"
nats: Permissions Violation for Publish to "bad" on connection [11]
$ echo $?
0
```

The `sub` command waits on a subscription, even though there is a permission violation.
```
$ nsc tool sub --nats nats://foo:foo@localhost:4222 bad
Listening on [bad]
nats: Permissions Violation for Subscription to "bad" on connection [4]
```

The `reply` command waits on a subscription, even though there is a permission violation.
```
$ nsc tool reply --nats nats://foo:foo@localhost:4222 bad hi
listening on [bad]
nats: Permissions Violation for Subscription to "bad" on connection [4]
```

### After change
With this change, `pub`, `sub`, and `reply` look like this when there is a permission error.

```
$ nsc tool pub --nats nats://foo:foo@localhost:4222 bad hi
nats: Permissions Violation for Publish to "bad" on connection [6]
Error: nats: Permissions Violation for Publish to "bad"
Usage:
  nsc tool pub [flags]

Examples:
nsc tool pub <subject> <opt_payload>

Flags:
  -a, --account string   account name
  -h, --help             help for pub
  -u, --user string      user name

Global Flags:
      --config-dir string     nsc config directory
      --data-dir string       nsc data store directory
  -i, --interactive           ask questions for various settings
      --keystore-dir string   nsc keystore directory
      --nats string           nats url, defaults to the operator's service URLs
  -K, --private-key string    Key used to sign. Can be specified as role (where applicable),
                              public key (private portion is retrieved)
                              or file path to a private key or private key

$ echo $?
1
```
