### PR TITLE
Change the wording on the bearer flag

### DIFF
--- a/cmd/edituser.go
+++ b/cmd/edituser.go
@@ -53,7 +53,7 @@ nsc edit user --name <n> --rm <subject>,...
 # To dynamically allow publishing to reply subjects, this works well for service responders:
 nsc edit user --name <n> --allow-pub-response
 
-# A permission to publish a response can be removed after a duration from when 
+# A permission to publish a response can be removed after a duration from when
 # the message was received:
 nsc edit user --name <n> --allow-pub-response --response-ttl 5s
 
@@ -439,7 +439,11 @@ func (p *UserPermissionLimits) Run(ctx ActionCtx, claim *jwt.UserPermissionLimit
 
 	if flags.Changed("bearer") {
 		claim.BearerToken = p.bearer
-		r.AddOK("changed bearer to %t", p.bearer)
+		if flags.Lookup("bearer").DefValue != fmt.Sprint(p.bearer) {
+			r.AddOK("changed bearer to %t", p.bearer)
+		} else {
+			r.AddOK("ignoring change to bearer - value is already %t", p.bearer)
+		}
 	}
 
 	var connTypes jwt.StringList

--- a/cmd/edituser_test.go
+++ b/cmd/edituser_test.go
@@ -365,7 +365,7 @@ func Test_EditUserBearerToken(t *testing.T) {
 
 	_, stderr, err = ExecuteCmd(createEditUserCmd(), "--name", "U", "--bearer=false")
 	require.NoError(t, err)
-	require.Contains(t, stderr, "changed bearer to false")
+	require.Contains(t, stderr, "ignoring change to bearer - value is already false")
 
 	u, err = ts.Store.ReadUserClaim("A", "U")
 	require.NoError(t, err)


### PR DESCRIPTION
This changes the wording on a log message when the `--bearer` flag is set.
```
# Default value for --bearer is false
$ nsc edit user --deny-sub foo
[ OK ] added deny sub "foo"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/dreamy_driscoll/myacc/myusr.creds`
[ OK ] edited user "myusr"

$ nsc edit user --deny-sub foo --bearer=false
[ OK ] ensured bearer is false
[ OK ] added deny sub "foo"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/dreamy_driscoll/myacc/myusr.creds`
[ OK ] edited user "myusr"

$ nsc edit user --deny-sub foo --bearer=true
[ OK ] ensured bearer is true
[ OK ] added deny sub "foo"
[ OK ] generated user creds file `~/.local/share/nats/nsc/keys/creds/dreamy_driscoll/myacc/myusr.creds`
[ OK ] edited user "myusr"
```

Fixes https://github.com/nats-io/nsc/issues/405