### PR TITLE
Set StoreRoot as dataDir if set

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -186,6 +186,7 @@ func LoadOrInit(configDir string, dataDir string, keystoreDir string) (*ToolConf
 		return nil, err
 	}
 
+	dataDirFlagSet := dataDir != ""
 	if dataDir == "" {
 		dataDir = home.NscDataHome(home.StoresSubDirName)
 	}
@@ -231,6 +232,9 @@ func LoadOrInit(configDir string, dataDir string, keystoreDir string) (*ToolConf
 			}
 			config.SetDefaults()
 		}
+	}
+	if dataDirFlagSet {
+		config.StoreRoot = dataDir
 	}
 
 	// trigger updating defaults

--- a/cmd/defaults_test.go
+++ b/cmd/defaults_test.go
@@ -47,11 +47,31 @@ func TestDefault_LoadNewOnExisting(t *testing.T) {
 	require.NoError(t, WriteJson(fp, cc))
 
 	ResetForTests()
-	tc, err := LoadOrInit(filepath.Join(ts.Dir, "config"), filepath.Join(ts.Dir, "store"), "")
+	tc, err := LoadOrInit(filepath.Join(ts.Dir, "config"), "", "")
 	require.NoError(t, err)
 	require.NotNil(t, tc)
 
 	require.Equal(t, ts.GetStoresRoot(), tc.StoreRoot)
+	require.Equal(t, "operator", tc.Operator)
+	require.Equal(t, "A", tc.Account)
+}
+
+func TestDefault_LoadNewOnExistingOverride(t *testing.T) {
+	ts := NewTestStore(t, "operator")
+	ts.AddAccount(t, "A")
+
+	var cc ContextConfig
+	cc.StoreRoot = ts.GetStoresRoot()
+	fp := filepath.Join(ts.Dir, fmt.Sprintf("%s.json", GetToolName()))
+	require.NoError(t, WriteJson(fp, cc))
+
+	ResetForTests()
+	dataDir := filepath.Join(ts.Dir, "store")
+	tc, err := LoadOrInit(filepath.Join(ts.Dir, "config"), dataDir, "")
+	require.NoError(t, err)
+	require.NotNil(t, tc)
+
+	require.Equal(t, dataDir, tc.StoreRoot)
 	require.Equal(t, "operator", tc.Operator)
 	require.Equal(t, "A", tc.Account)
 }


### PR DESCRIPTION
### Before
With `--data-dir`, Current Store Dir taken from config file.
```
$ nsc --config-dir "~/.config/nats/nsc" --data-dir "/tmp/data-dir" --keystore-dir "/tmp/keystore-dir" env
+----------------------------------------------------------------------------------------------------------+
|                                             NSC Environment                                              |
+--------------------+-----+-------------------------------------------------------------------------------+
| Setting            | Set | Effective Value                                                               |
+--------------------+-----+-------------------------------------------------------------------------------+
| $NSC_CWD_ONLY      | No  | If set, default operator/account from cwd only                                |
| $NSC_NO_GIT_IGNORE | No  | If set, no .gitignore files written                                           |
| $NKEYS_PATH        | No  | /tmp/keystore-dir                                                             |
| $NSC_HOME          | No  | ~/.config/nats/nsc                                                            |
| $NATS_CA           | No  | If set, root CAs in the referenced file will be used for nats connections     |
|                    |     | If not set, will default to the system trust store                            |
| $NATS_KEY          | No  | If set, the tls key in the referenced file will be used for nats connections  |
| $NATS_CERT         | No  | If set, the tls cert in the referenced file will be used for nats connections |
+--------------------+-----+-------------------------------------------------------------------------------+
| From CWD           |     | No                                                                            |
| Default Stores Dir |     | ~/.local/share/nats/nsc/stores                                                |
| Current Store Dir  |     | /from/config                                                                  |
| Current Operator   |     | dreamy_driscoll                                                               |
| Current Account    |     | myacc                                                                         |
| Root CAs to trust  |     | Default: System Trust Store                                                   |
+--------------------+-----+-------------------------------------------------------------------------------+
```

### After
With `--data-dir`, Current Store Dir taken from command line.
```
$ nsc --config-dir "~/.config/nats/nsc" --data-dir "/tmp/data-dir" --keystore-dir "/tmp/keystore-dir" env
+----------------------------------------------------------------------------------------------------------+
|                                             NSC Environment                                              |
+--------------------+-----+-------------------------------------------------------------------------------+
| Setting            | Set | Effective Value                                                               |
+--------------------+-----+-------------------------------------------------------------------------------+
| $NSC_CWD_ONLY      | No  | If set, default operator/account from cwd only                                |
| $NSC_NO_GIT_IGNORE | No  | If set, no .gitignore files written                                           |
| $NKEYS_PATH        | No  | /tmp/keystore-dir                                                             |
| $NSC_HOME          | No  | ~/.config/nats/nsc                                                            |
| $NATS_CA           | No  | If set, root CAs in the referenced file will be used for nats connections     |
|                    |     | If not set, will default to the system trust store                            |
| $NATS_KEY          | No  | If set, the tls key in the referenced file will be used for nats connections  |
| $NATS_CERT         | No  | If set, the tls cert in the referenced file will be used for nats connections |
+--------------------+-----+-------------------------------------------------------------------------------+
| From CWD           |     | No                                                                            |
| Default Stores Dir |     | ~/.local/share/nats/nsc/stores                                                |
| Current Store Dir  |     | /tmp/data-dir                                                                 |
| Current Operator   |     | dreamy_driscoll                                                               |
| Current Account    |     | myacc                                                                         |
| Root CAs to trust  |     | Default: System Trust Store                                                   |
+--------------------+-----+-------------------------------------------------------------------------------+
```

Without `--data-dir`, Current Store Dir taken from config file.
```
$ nsc --config-dir "~/.config/nats/nsc" --keystore-dir "/tmp/keystore-dir" env
+----------------------------------------------------------------------------------------------------------+
|                                             NSC Environment                                              |
+--------------------+-----+-------------------------------------------------------------------------------+
| Setting            | Set | Effective Value                                                               |
+--------------------+-----+-------------------------------------------------------------------------------+
| $NSC_CWD_ONLY      | No  | If set, default operator/account from cwd only                                |
| $NSC_NO_GIT_IGNORE | No  | If set, no .gitignore files written                                           |
| $NKEYS_PATH        | No  | /tmp/keystore-dir                                                             |
| $NSC_HOME          | No  | ~/.config/nats/nsc                                                            |
| $NATS_CA           | No  | If set, root CAs in the referenced file will be used for nats connections     |
|                    |     | If not set, will default to the system trust store                            |
| $NATS_KEY          | No  | If set, the tls key in the referenced file will be used for nats connections  |
| $NATS_CERT         | No  | If set, the tls cert in the referenced file will be used for nats connections |
+--------------------+-----+-------------------------------------------------------------------------------+
| From CWD           |     | No                                                                            |
| Default Stores Dir |     | ~/.local/share/nats/nsc/stores                                                |
| Current Store Dir  |     | /from/config                                                                  |
| Current Operator   |     | dreamy_driscoll                                                               |
| Current Account    |     | myacc                                                                         |
| Root CAs to trust  |     | Default: System Trust Store                                                   |
+--------------------+-----+-------------------------------------------------------------------------------+
```

Fixes https://github.com/nats-io/nsc/issues/458