### PR TITLE
[FIX] when parsing start/expiry expressions the value must be integral

### DIFF
--- a/cmd/timeparams.go
+++ b/cmd/timeparams.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	cli "github.com/nats-io/cliprompts/v2"
@@ -119,6 +120,9 @@ func (p *TimeParams) ExpiryDate() (int64, error) {
 func ParseExpiry(s string) (int64, error) {
 	if s == "" || s == "0" {
 		return 0, nil
+	}
+	if strings.Contains(s, ".") {
+		return 0, fmt.Errorf("start/expiry must be an integer value: %v", s)
 	}
 	// try to parse directly
 	t, err := time.Parse("2006-01-02 15:04:05 UTC", s)

--- a/cmd/timeparams_test.go
+++ b/cmd/timeparams_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 The NATS Authors
+ * Copyright 2018-2022 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -43,6 +43,7 @@ func TestParseExpiry(t *testing.T) {
 		{"3w", time.Now().AddDate(0, 0, 7*3).Unix(), false},
 		{"2M", time.Now().AddDate(0, 2, 0).Unix(), false},
 		{"2y", time.Now().AddDate(2, 0, 0).Unix(), false},
+		{"2.5d", 0, true},
 	}
 	for _, d := range tests {
 		v, err := ParseExpiry(d.input)


### PR DESCRIPTION
#FIX 505