### PR TITLE
Fix creation of extra nkey with --sk generate

### DIFF
--- a/cmd/signingkeyseditor.go
+++ b/cmd/signingkeyseditor.go
@@ -39,6 +39,9 @@ func (e *SigningKeysParams) BindFlags(flagName string, shorthand string, kind nk
 }
 
 func (e *SigningKeysParams) valid(s string) error {
+	if s == "generate" {
+		return nil
+	}
 	_, err := e.resolve(s)
 	return err
 }


### PR DESCRIPTION
The command `nsc edit operator --sk generate` currently save 2 nkeys in the store:
 - A first one when doing the Validate,
 - a second one when doing the Run.

This prevent the validate to generate a nkey and save it.