### PR TITLE
Correct readme chmod to chown reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ docker run --rm -it -v $(pwd)/nsc:/nsc synadia/nats-box:latest
 
 # In case NSC not initialized already:
 nats-box:~# nsc init
-nats-box:~# chmod -R 1000:1000 /nsc
+nats-box:~# chown -R 1000:1000 /nsc
 $ tree -L 2 nsc/
 nsc/
  ├── accounts


### PR DESCRIPTION
The docker example references chmod but it should be chown.