### PR TITLE
Set Default output to help

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -196,8 +196,8 @@ var rootCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// we are only called when asked for the version
-		cmd.Printf("nsc version %s\n", cmd.Version)
+		// print command help by default
+		cmd.Help()
 	},
 }
 


### PR DESCRIPTION
This PR changes the default output of `nsc` from printing the version to showing the help.