### PR TITLE
chore: fix example for `describe jwt`

### DIFF
--- a/cmd/describejwt.go
+++ b/cmd/describejwt.go
@@ -31,7 +31,7 @@ func createDescribeJwtCmd() *cobra.Command {
 		Use:          "jwt",
 		Short:        "Describe a jwt/creds file",
 		Args:         MaxArgs(0),
-		Example:      fmt.Sprintf(`%s describe -f pathorurl`, GetToolName()),
+		Example:      fmt.Sprintf(`%s describe jwt -f pathorurl`, GetToolName()),
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := RunStoreLessAction(cmd, args, &params); err != nil {


### PR DESCRIPTION
The current example is stated as:

```
$ nsc describe jwt
Error: file is required
Usage:
  nsc describe jwt [flags]

Examples:
nsc describe -f pathorurl
```

When the example should be `nsc describe jwt -f pathorurl` as the other command is non-existing