### PR TITLE
Add `select` Command

### DIFF
--- a/cmd/select.go
+++ b/cmd/select.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018-2022 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	GetRootCmd().AddCommand(createSelecteCmd())
+}
+
+func createSelecteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "select",
+		Short: "Set the current operator or account",
+	}
+	cmd.AddCommand(selectOperatorCmd())
+	cmd.AddCommand(selectAccountCmd())
+	return cmd
+}
+
+func selectOperatorCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "operator",
+		Short: "set the operator",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if NscCwdOnly {
+				return fmt.Errorf("%s is set - change your cwd to use context", NscCwdOnlyEnv)
+			}
+
+			current := GetConfig()
+			if err := current.ContextConfig.Update("", args[0], ""); err != nil {
+				return err
+			}
+
+			return current.Save()
+		},
+	}
+}
+
+func selectAccountCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "account",
+		Short: "set the account",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return err
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if NscCwdOnly {
+				return fmt.Errorf("%s is set - change your cwd to use context", NscCwdOnlyEnv)
+			}
+
+			current := GetConfig()
+			if err := current.ContextConfig.Update("", "", args[0]); err != nil {
+				return err
+			}
+
+			return current.Save()
+		},
+	}
+}

--- a/cmd/select.go
+++ b/cmd/select.go
@@ -16,8 +16,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -47,10 +45,6 @@ func selectOperatorCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if NscCwdOnly {
-				return fmt.Errorf("%s is set - change your cwd to use context", NscCwdOnlyEnv)
-			}
-
 			current := GetConfig()
 			if err := current.ContextConfig.Update("", args[0], ""); err != nil {
 				return err
@@ -73,10 +67,6 @@ func selectAccountCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if NscCwdOnly {
-				return fmt.Errorf("%s is set - change your cwd to use context", NscCwdOnlyEnv)
-			}
-
 			current := GetConfig()
 			if err := current.ContextConfig.Update("", "", args[0]); err != nil {
 				return err

--- a/cmd/select_test.go
+++ b/cmd/select_test.go
@@ -18,65 +18,63 @@ package cmd
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSelectAccount(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	ts := NewTestStore(t, "test")
 	defer ts.Done(t)
 
 	_, _, err := ExecuteCmd(selectAccountCmd(), "A")
-	assert.NotNil(err)
+	require.NotNil(err)
 
 	ts.AddAccount(t, "A")
 	ts.AddAccount(t, "B")
 
 	_, _, err = ExecuteCmd(selectAccountCmd(), "A")
-	assert.Nil(err)
+	require.Nil(err)
 	conf := GetConfig()
-	assert.Equal(conf.Account, "A")
+	require.Equal(conf.Account, "A")
 
 	_, _, err = ExecuteCmd(selectAccountCmd(), "B")
-	assert.Nil(err)
+	require.Nil(err)
 	conf = GetConfig()
-	assert.Equal(conf.Account, "B")
+	require.Equal(conf.Account, "B")
 
 	_, _, err = ExecuteCmd(selectAccountCmd(), "NO")
-	if assert.NotNil(err) {
-		assert.Contains(err.Error(), "\"NO\" not in accounts for operator")
-	}
+	require.NotNil(err)
+	require.Contains(err.Error(), "\"NO\" not in accounts for operator")
 
 	conf = GetConfig()
-	assert.Equal(conf.Account, "B")
+	require.Equal(conf.Account, "B")
 }
 
 func TestSelectOperator(t *testing.T) {
-	assert := assert.New(t)
+	require := require.New(t)
 	ts := NewTestStore(t, "test")
 	defer ts.Done(t)
 
 	_, _, err := ExecuteCmd(selectOperatorCmd(), "test")
-	assert.Nil(err)
+	require.Nil(err)
 
 	ts.AddOperator(t, "test2")
 	ts.AddOperator(t, "test3")
 
 	_, _, err = ExecuteCmd(selectOperatorCmd(), "test2")
-	assert.Nil(err)
+	require.Nil(err)
 	conf := GetConfig()
-	assert.Equal(conf.Operator, "test2")
+	require.Equal(conf.Operator, "test2")
 
 	_, _, err = ExecuteCmd(selectOperatorCmd(), "test3")
-	assert.Nil(err)
+	require.Nil(err)
 	conf = GetConfig()
-	assert.Equal(conf.Operator, "test3")
+	require.Equal(conf.Operator, "test3")
 
 	_, _, err = ExecuteCmd(selectOperatorCmd(), "NO")
-	if assert.NotNil(err) {
-		assert.Contains(err.Error(), "operator \"NO\" not in")
-	}
+	require.NotNil(err)
+	require.Contains(err.Error(), "operator \"NO\" not in")
 
 	conf = GetConfig()
-	assert.Equal(conf.Operator, "test3")
+	require.Equal(conf.Operator, "test3")
 }

--- a/cmd/select_test.go
+++ b/cmd/select_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2018-2022 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSelectAccount(t *testing.T) {
+	assert := assert.New(t)
+	ts := NewTestStore(t, "test")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(selectAccountCmd(), "A")
+	assert.NotNil(err)
+
+	ts.AddAccount(t, "A")
+	ts.AddAccount(t, "B")
+
+	_, _, err = ExecuteCmd(selectAccountCmd(), "A")
+	assert.Nil(err)
+	conf := GetConfig()
+	assert.Equal(conf.Account, "A")
+
+	_, _, err = ExecuteCmd(selectAccountCmd(), "B")
+	assert.Nil(err)
+	conf = GetConfig()
+	assert.Equal(conf.Account, "B")
+
+	_, _, err = ExecuteCmd(selectAccountCmd(), "NO")
+	if assert.NotNil(err) {
+		assert.Contains(err.Error(), "\"NO\" not in accounts for operator")
+	}
+
+	conf = GetConfig()
+	assert.Equal(conf.Account, "B")
+}
+
+func TestSelectOperator(t *testing.T) {
+	assert := assert.New(t)
+	ts := NewTestStore(t, "test")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(selectOperatorCmd(), "test")
+	assert.Nil(err)
+
+	ts.AddOperator(t, "test2")
+	ts.AddOperator(t, "test3")
+
+	_, _, err = ExecuteCmd(selectOperatorCmd(), "test2")
+	assert.Nil(err)
+	conf := GetConfig()
+	assert.Equal(conf.Operator, "test2")
+
+	_, _, err = ExecuteCmd(selectOperatorCmd(), "test3")
+	assert.Nil(err)
+	conf = GetConfig()
+	assert.Equal(conf.Operator, "test3")
+
+	_, _, err = ExecuteCmd(selectOperatorCmd(), "NO")
+	if assert.NotNil(err) {
+		assert.Contains(err.Error(), "operator \"NO\" not in")
+	}
+
+	conf = GetConfig()
+	assert.Equal(conf.Operator, "test3")
+}


### PR DESCRIPTION
This PR adds the `select` verb to the `nsc` command. The goal was to more explicitly expose the functionality to switch operators and accounts and to make it as easy as possible.