### PR TITLE
Fix: null pointer error in add user interactive mode

### DIFF
--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -196,6 +196,9 @@ func validUserSigners(ctx ActionCtx, accName string) ([]string, error) {
 			signers = append(signers, signingKey)
 		}
 	}
+	if opc.StrictSigningKeyUsage && len(ac.SigningKeys) == 0 {
+		return nil, errors.New("operator requires signing keys but account does not have any configured")
+	}
 	return signers, nil
 }
 


### PR DESCRIPTION
When an operator is configured to require a signing key (`StrictSigningKeyUsage`) but there are no signing keys configure on an account, using interactive mode to create a user results in a null pointer error: the resolved signing key slice is empty and interactive mode attempts to auto select index 0 which doesn't exist.

This PR will return a descriptive error to the user indicating that signing keys are required but no signing keys are available for use.