### PR TITLE
[FEAT] export an entire environment (jwts and keys)

### DIFF
--- a/cmd/exportkeys_test.go
+++ b/cmd/exportkeys_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -235,4 +235,26 @@ func Test_ExportXKeyInContext(t *testing.T) {
 	_, _, err = ExecuteCmd(createExportKeysCmd(), "--dir", exportDir, "-A")
 	require.NoError(t, err)
 	requireExportedKey(t, exportDir, xPK)
+}
+
+func Test_ExportKeyJwt(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	ts.AddAccount(t, "A")
+	ts.AddUser(t, "A", "U")
+
+	o := ts.GetOperatorPublicKey(t)
+	a := ts.GetAccountPublicKey(t, "A")
+	u := ts.GetUserPublicKey(t, "A", "U")
+
+	exportDir := filepath.Join(ts.Dir, "export")
+	_, _, err := ExecuteCmd(createExportKeysCmd(), "--dir", exportDir, "-A", "--include-jwts")
+	require.NoError(t, err)
+	requireExportedKey(t, exportDir, o)
+	require.FileExists(t, filepath.Join(exportDir, fmt.Sprintf("%s.jwt", o)))
+	requireExportedKey(t, exportDir, a)
+	require.FileExists(t, filepath.Join(exportDir, fmt.Sprintf("%s.jwt", a)))
+	requireExportedKey(t, exportDir, u)
+	require.FileExists(t, filepath.Join(exportDir, fmt.Sprintf("%s.jwt", u)))
 }


### PR DESCRIPTION
added `--include-jwtws` option to make it easy to export not only the keys, but also the configurations in the current operator tree. Paired with `nsc fix` you can recreate/mode an nsc environment.