### PR TITLE
[FEAT] added single flag to set all the data/keys/config to one containing dir

### DIFF
--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -70,4 +71,16 @@ func TestEnv_FailsBadAccount(t *testing.T) {
 	_, _, err := ExecuteCmd(createEnvCmd(), "-a", "A")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "\"A\" not in accounts for operator \"O\"")
+}
+
+func TestAllDir(t *testing.T) {
+	p := MakeTempDir(t)
+	defer os.RemoveAll(p)
+
+	_, stderr, err := ExecuteCmd(rootCmd, "env", "--all-dirs", p)
+	require.NoError(t, err)
+	stderr = StripTableDecorations(stderr)
+	require.Contains(t, stderr, fmt.Sprintf("$NKEYS_PATH Yes %s", p))
+	require.Contains(t, stderr, fmt.Sprintf("$NSC_HOME Yes %s", p))
+	require.Contains(t, stderr, fmt.Sprintf("Current Store Dir %s", p))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,12 +30,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var ConfigDirFlag string
-var KeysDirFlag string
-var DataDirFlag string
+var (
+	ConfigDirFlag   string
+	KeysDirFlag     string
+	DataDirFlag     string
+	AllDirFlag      string
+	KeyPathFlag     string
+	InteractiveFlag bool
+)
 
-var KeyPathFlag string
-var InteractiveFlag bool
 var NscCwdOnly bool
 var ErrNoOperator = errors.New("set an operator -- 'nsc env -o operatorName'")
 
@@ -155,6 +158,12 @@ var rootCmd = &cobra.Command{
 	Short: "nsc creates NATS operators, accounts, users, and manage their permissions.",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		var err error
+		if AllDirFlag != "" {
+			ConfigDirFlag = AllDirFlag
+			DataDirFlag = AllDirFlag
+			KeysDirFlag = AllDirFlag
+		}
+
 		// if the flag is set we use it, if not check the old env
 		if ConfigDirFlag != "" {
 			if ConfigDirFlag, err = Expand(ConfigDirFlag); err != nil {
@@ -256,6 +265,6 @@ func HoistRootFlags(cmd *cobra.Command) *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&ConfigDirFlag, "config-dir", "", "", "nsc config directory")
 	cmd.PersistentFlags().StringVarP(&DataDirFlag, "data-dir", "", "", "nsc data store directory")
 	cmd.PersistentFlags().StringVarP(&KeysDirFlag, "keystore-dir", "", "", "nsc keystore directory")
-
+	cmd.PersistentFlags().StringVarP(&AllDirFlag, "all-dirs", "H", "", "sets --config-dir, --data-dir, and --keystore-dir to the same value")
 	return cmd
 }

--- a/cmd/util_test.go
+++ b/cmd/util_test.go
@@ -70,6 +70,10 @@ func ResetSharedFlags() {
 	Json = false
 	Raw = false
 	JsonPath = ""
+	AllDirFlag = ""
+	ConfigDirFlag = ""
+	DataDirFlag = ""
+	KeysDirFlag = ""
 }
 
 func NewEmptyStore(t *testing.T) *TestStore {


### PR DESCRIPTION
added `--all-dirs` option to store config, data, keys under the same directory - this is useful for generating test configurations