### PR TITLE
prevent entity names with path separators

### DIFF
--- a/cmd/addaccount.go
+++ b/cmd/addaccount.go
@@ -180,6 +180,11 @@ func (p *AddAccountParams) Validate(ctx ActionCtx) error {
 		return fmt.Errorf("account name is required")
 	}
 
+	if strings.Contains(p.name, "/") || strings.Contains(p.name, "\\") {
+		ctx.CurrentCmd().SilenceUsage = false
+		return fmt.Errorf("name cannot contain '/' or '\\'")
+	}
+
 	if p.name == "*" {
 		p.name = GetRandomName(0)
 	}

--- a/cmd/addaccount.go
+++ b/cmd/addaccount.go
@@ -180,7 +180,7 @@ func (p *AddAccountParams) Validate(ctx ActionCtx) error {
 		return fmt.Errorf("account name is required")
 	}
 
-	if strings.Contains(p.name, "/") || strings.Contains(p.name, "\\") {
+	if strings.ContainsAny(p.name, "/\\") {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("name cannot contain '/' or '\\'")
 	}

--- a/cmd/addaccount_test.go
+++ b/cmd/addaccount_test.go
@@ -284,3 +284,12 @@ func Test_AddAccount_Pubs(t *testing.T) {
 	require.ElementsMatch(t, cc.DefaultPermissions.Pub.Deny, []string{"foo", "bar"})
 	require.ElementsMatch(t, cc.DefaultPermissions.Sub.Deny, []string{"bar"})
 }
+
+func Test_AddAccountBadName(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(CreateAddAccountCmd(), "A/B")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot contain '/' or '\\'")
+}

--- a/cmd/addoperator.go
+++ b/cmd/addoperator.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	cli "github.com/nats-io/cliprompts/v2"
 	"github.com/nats-io/jwt/v2"
@@ -247,6 +248,10 @@ func (p *AddOperatorParams) Validate(ctx ActionCtx) error {
 	if p.name == "" {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("operator name is required")
+	}
+	if strings.Contains(p.name, "/") || strings.Contains(p.name, "\\") {
+		ctx.CurrentCmd().SilenceUsage = false
+		return fmt.Errorf("name cannot contain '/' or '\\'")
 	}
 
 	if err = p.TimeParams.Validate(); err != nil {

--- a/cmd/addoperator.go
+++ b/cmd/addoperator.go
@@ -249,7 +249,7 @@ func (p *AddOperatorParams) Validate(ctx ActionCtx) error {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("operator name is required")
 	}
-	if strings.Contains(p.name, "/") || strings.Contains(p.name, "\\") {
+	if strings.ContainsAny(p.name, "/\\") {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("name cannot contain '/' or '\\'")
 	}

--- a/cmd/addoperator_test.go
+++ b/cmd/addoperator_test.go
@@ -329,3 +329,12 @@ func TestImportReIssuedOperator(t *testing.T) {
 	require.NoError(t, err)
 	checkOp(pubNew)
 }
+
+func Test_AddOperatorBadName(t *testing.T) {
+	ts := NewEmptyStore(t)
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(createAddOperatorCmd(), "A/B")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot contain '/' or '\\'")
+}

--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -213,6 +213,11 @@ func (p *AddUserParams) Validate(ctx ActionCtx) error {
 		return fmt.Errorf("user name is required")
 	}
 
+	if strings.Contains(p.userName, "/") || strings.Contains(p.userName, "\\") {
+		ctx.CurrentCmd().SilenceUsage = false
+		return fmt.Errorf("name cannot contain '/' or '\\'")
+	}
+
 	if p.userName == "*" {
 		p.userName = GetRandomName(0)
 	}

--- a/cmd/adduser.go
+++ b/cmd/adduser.go
@@ -213,7 +213,7 @@ func (p *AddUserParams) Validate(ctx ActionCtx) error {
 		return fmt.Errorf("user name is required")
 	}
 
-	if strings.Contains(p.userName, "/") || strings.Contains(p.userName, "\\") {
+	if strings.ContainsAny(p.userName, "/\\") {
 		ctx.CurrentCmd().SilenceUsage = false
 		return fmt.Errorf("name cannot contain '/' or '\\'")
 	}

--- a/cmd/adduser_test.go
+++ b/cmd/adduser_test.go
@@ -591,3 +591,14 @@ func Test_AddUsersWithSharedSigningKey(t *testing.T) {
 	_, _, err = ExecuteCmd(HoistRootFlags(CreateAddUserCmd()), "u", "--account", "B", "-K", sk)
 	require.NoError(t, err)
 }
+
+func Test_AddUserBadName(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	ts.AddAccount(t, "A")
+
+	_, _, err := ExecuteCmd(CreateAddUserCmd(), "A/B")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "name cannot contain '/' or '\\'")
+}


### PR DESCRIPTION
[FIX] entity names using a path separator are parsed as a path, which then writes them to the wrong location in the store - this fix generates an error if for such names

FIXES #398