### PR TITLE
[FIX] default go marshaller encodes HTML entities - changed so that when describe is outputting JSON to the console, to not do so

### DIFF
--- a/cmd/describe.go
+++ b/cmd/describe.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -94,9 +94,13 @@ func bodyAsJson(data []byte) ([]byte, error) {
 	if err := json.Unmarshal(d, &m); err != nil {
 		return nil, fmt.Errorf("error parsing json: %v", err)
 	}
-	f, err := json.MarshalIndent(m, "", " ")
-	if err != nil {
+
+	j := &bytes.Buffer{}
+	encoder := json.NewEncoder(j)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", " ")
+	if err := encoder.Encode(m); err != nil {
 		return nil, fmt.Errorf("error formatting json: %v", err)
 	}
-	return f, nil
+	return j.Bytes(), nil
 }

--- a/cmd/describeaccount_test.go
+++ b/cmd/describeaccount_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -237,4 +237,16 @@ func TestDescribeAccount_Callout(t *testing.T) {
 	require.Contains(t, out, fmt.Sprintf(" | %s", uPK))
 	require.Contains(t, out, fmt.Sprintf(" | %s", aPK))
 	require.Contains(t, out, fmt.Sprintf(" | %s", xPK))
+}
+
+func TestDescribeAccount_SubjectEncoding(t *testing.T) {
+	ts := NewTestStore(t, "test")
+	defer ts.Done(t)
+
+	ts.AddAccount(t, "A")
+	ts.AddExport(t, "A", jwt.Stream, "foo.>", true)
+
+	out, _, err := ExecuteCmd(rootCmd, "describe", "account", "--json")
+	require.NoError(t, err)
+	require.Contains(t, out, "foo.>")
 }


### PR DESCRIPTION
FIXES #559 