### PR TITLE
Get jwt library v1 out of the nsc binary

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -125,4 +125,19 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.canonical
 
+      - name: Bad versions creep defense
+        id: go-module-versions
+        # The go.mod includes tests, and some of our tests explicitly pull in jwtv1, which is unmaintained and has security issues.
+        # It's only in the tests, so that's not critical enough to need to rewrite things at this time.
+        # But we don't want the _binary_ to link against v1.  So we want to check what the actual binary links against.
+        # Add whatever other checks we care about here.
+        run: |
+          go build
+          go version -m ./nsc > versions
+          if grep -qsE '^[[:space:]]+dep[[:space:]]+github\.com/nats-io/jwt[[:space:]]' versions; then
+            echo "::error title=Bad dependency in binary::JWT library v1 detected"
+            exit 1
+          fi
+        if: matrix.canonical
+
 #EOF

--- a/cmd/importaccount_test.go
+++ b/cmd/importaccount_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/nats-io/jwt"
+	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/importuser_test.go
+++ b/cmd/importuser_test.go
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/nats-io/jwt"
+	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/pubkeyparams.go
+++ b/cmd/pubkeyparams.go
@@ -19,9 +19,11 @@ import (
 	"fmt"
 
 	cli "github.com/nats-io/cliprompts/v2"
-	"github.com/nats-io/jwt"
+	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
+
 	"github.com/nats-io/nsc/v2/cmd/store"
+
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/revoke_listusers_test.go
+++ b/cmd/revoke_listusers_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/jwt"
+	"github.com/nats-io/jwt/v2"
 
 	"github.com/stretchr/testify/require"
 )

--- a/cmd/revokeuser_test.go
+++ b/cmd/revokeuser_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/nats-io/jwt"
+	"github.com/nats-io/jwt/v2"
 
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
* Add a CI push test to fail the build if the binary pulls in jwt library v1
  + this should be extensible enough as a pattern to let us handle any other deny-list libraries we want to keep out
* Fix `cmd/pubkeyparams.go` which accidentally pulled in jwtv1 not jwtv2, to get the constant `jwt.All` (`"*"`)
* Change all test files which didn't explicitly pull in jwt/v1 _as_ `jwtv1` to bring in jwt/v2 instead
  + If the test says jwtv1 explicitly, it's assumed to be deliberate

As long as any tests pull in JWTv1, the go.mod file will continue to reference v1, so we can't just audit the module file for sanity; we instead build the binary and look at what it's actually using.
