### PR TITLE
Add vcsinfo to binary

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,7 +46,7 @@ builds:
       - goos: freebsd
         goarch: 386
     binary: nsc
-    main: ./main.go
+    main: .
     env:
       - CGO_ENABLED=0
     # reproducible builds:


### PR DESCRIPTION
This removes nsc being included as a dependency of itself in the binary (which matches some vuln scanners causing false positives).

before:

```
$ go version -m build/nsc_darwin_arm64/nsc 
...
	path	command-line-arguments
...
	dep	github.com/nats-io/jsm.go	v0.0.35	h1:l03xuGttRA9b81Q0P/WEGm3e5DYof743ZEI4nQR3PUs=
	dep	github.com/nats-io/jwt/v2	v2.4.1	h1:Y35W1dgbbz2SQUYDPCaclXcuqleVmpbRa7646Jf2EX4=
	dep	github.com/nats-io/nats.go	v1.24.0	h1:CRiD8L5GOQu/DcfkmgBcTTIQORMwizF+rPk6T0RaHVQ=
	dep	github.com/nats-io/nkeys	v0.4.4	h1:xvBJ8d69TznjcQl9t6//Q5xXuVhyYiSos6RPtvQNTwA=
	dep	github.com/nats-io/nsc/v2	(devel)	<<-- should remove this
	dep	github.com/nats-io/nuid	v1.0.1	h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
```

after:

```
build/nsc_darwin_arm64/nsc: go1.19.5
	path	github.com/nats-io/nsc/v2
	mod	github.com/nats-io/nsc/v2	(devel)	
// no dep
```