### PR TITLE
Clarify system account edits which requires JetStream limits to be set to 0

### DIFF
--- a/cmd/editaccount.go
+++ b/cmd/editaccount.go
@@ -249,10 +249,8 @@ func (p *EditAccountParams) doDisableJetStream(r *store.Report) error {
 	}
 	p.claim.Limits.JetStreamLimits = jwt.JetStreamLimits{}
 	r.AddOK("deleted global limit")
-	if p.claim.Limits.JetStreamTieredLimits != nil {
-		for k := range p.claim.Limits.JetStreamTieredLimits {
-			r.AddOK("deleted tier limit %s", k)
-		}
+	for k := range p.claim.Limits.JetStreamTieredLimits {
+		r.AddOK("deleted tier limit %s", k)
 	}
 	p.claim.Limits.JetStreamTieredLimits = nil
 	return nil

--- a/cmd/editaccount_test.go
+++ b/cmd/editaccount_test.go
@@ -365,7 +365,6 @@ func Test_EditSysAccount(t *testing.T) {
 	// test setting any flag will generate an error and the flag is reported
 	jsOptions := []string{
 		"js-max-bytes-required",
-
 		"js-tier",
 		"js-mem-storage",
 		"js-disk-storage",
@@ -391,4 +390,14 @@ func Test_EditSysAccount(t *testing.T) {
 	// defaults are removed automatically
 	_, _, err = ExecuteCmd(createEditAccount(), "SYS", "--tag", "A")
 	require.NoError(t, err)
+}
+
+func Test_TierRmAndDisabled(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	ts.AddAccount(t, "A")
+
+	_, _, err := ExecuteCmd(createEditAccount(), "A", "--rm-js-tier", "1", "--js-disable")
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "js-disable is exclusive of all other js options")
 }


### PR DESCRIPTION
[FIX] clarified check added to edits of the system account which prevented editing due to JetStream default values in the flag - added a flag that sets the values for the jetstream setting (--js-disable) which sets the values to 0

Fixes #569