### PR TITLE
YAML Enginering: quote go-version string

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.19
+          go-version: '1.19'
           check-latest: true
 
       - name: Install cosign


### PR DESCRIPTION
Try to ensure that when we switch to Go 1.20 we don't forget to quote the string to protect against the version being parsed as `1.2`.
