### PR TITLE
[FIX] generate --mem-resolver performance in setups that have huge number of users

### DIFF
--- a/cmd/generateserverconfig.go
+++ b/cmd/generateserverconfig.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 The NATS Authors
+ * Copyright 2018-2023 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -249,16 +249,18 @@ func (p *GenerateServerConfigParams) Run(ctx ActionCtx) (store.Status, error) {
 		}
 		p.generator.Add(d)
 
-		users, err := s.ListEntries(store.Accounts, n, store.Users)
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range users {
-			d, err := s.Read(store.Accounts, n, store.Users, store.JwtName(u))
+		if p.nkeyConfig {
+			users, err := s.ListEntries(store.Accounts, n, store.Users)
 			if err != nil {
 				return nil, err
 			}
-			p.generator.Add(d)
+			for _, u := range users {
+				d, err := s.Read(store.Accounts, n, store.Users, store.JwtName(u))
+				if err != nil {
+					return nil, err
+				}
+				p.generator.Add(d)
+			}
 		}
 	}
 


### PR DESCRIPTION
[FIX] generate command has a generic processing engine but when generating anything but nkey configurations, it shouldn't look at the users as this could significantly degrate generation performance when that data is not needed.