### PR TITLE
case sensitive tags

### DIFF
--- a/cmd/editaccount.go
+++ b/cmd/editaccount.go
@@ -57,6 +57,7 @@ func createEditAccount() *cobra.Command {
 			return RunAction(cmd, args, params)
 		},
 	}
+	cmd.Flags().BoolVarP(&params.caseSensitiveTags, "case-sensitive-tags", "", false, "allow tags values that are not lowercase (false)")
 	cmd.Flags().StringSliceVarP(&params.tags, "tag", "", nil, "add tags for user - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringSliceVarP(&params.rmTags, "rm-tag", "", nil, "remove tag - comma separated list or option can be specified multiple times")
 	params.conns = -1

--- a/cmd/editaccount_test.go
+++ b/cmd/editaccount_test.go
@@ -524,3 +524,22 @@ func Test_EnableTierNoOtherFlag(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, "rm-js-tier is exclusive of all other js options", err.Error())
 }
+
+func Test_EditAccountCaseSensitiveTags(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+	ts.AddAccount(t, "A")
+
+	_, _, err := ExecuteCmd(createEditAccount(), "A", "--case-sensitive-tags", "--tag", "One,Two,three")
+	require.Nil(t, err)
+
+	_, _, err = ExecuteCmd(createEditAccount(), "A", "--case-sensitive-tags", "--rm-tag", "Three")
+	require.Error(t, err)
+
+	_, _, err = ExecuteCmd(createEditAccount(), "A", "--case-sensitive-tags", "--rm-tag", "three")
+	require.NoError(t, err)
+
+	ac, err := ts.Store.ReadAccountClaim("A")
+	require.NoError(t, err)
+	require.Equal(t, ac.Tags, jwt.TagList{"One", "Two"})
+}

--- a/cmd/editoperator.go
+++ b/cmd/editoperator.go
@@ -40,6 +40,7 @@ func createEditOperatorCmd() *cobra.Command {
 	}
 	params.signingKeys.BindFlags("sk", "", nkeys.PrefixByteOperator, cmd)
 	cmd.Flags().StringSliceVarP(&params.rmSigningKeys, "rm-sk", "", nil, "remove signing key - comma separated list or option can be specified multiple times")
+	cmd.Flags().BoolVarP(&params.caseSensitiveTags, "case-sensitive-tags", "", false, "allow tags values that are not lowercase (false)")
 	cmd.Flags().StringSliceVarP(&params.tags, "tag", "", nil, "add tags for user - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringSliceVarP(&params.rmTags, "rm-tag", "", nil, "remove tag - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringVarP(&params.asu, "account-jwt-server-url", "u", "", "set account jwt server url for nsc sync (only http/https or nats service (nats/tls/ws/wss) urls supported if updating with nsc)")

--- a/cmd/editoperator_test.go
+++ b/cmd/editoperator_test.go
@@ -420,3 +420,21 @@ func Test_CannotSetRequireSKWithoutSK(t *testing.T) {
 	require.False(t, oc.StrictSigningKeyUsage)
 	require.Empty(t, oc.SigningKeys)
 }
+
+func Test_EditOperatorCaseSensitiveTags(t *testing.T) {
+	ts := NewTestStore(t, "O")
+	defer ts.Done(t)
+
+	_, _, err := ExecuteCmd(createEditOperatorCmd(), "--case-sensitive-tags", "--tag", "One,Two,three")
+	require.Nil(t, err)
+
+	_, _, err = ExecuteCmd(createEditOperatorCmd(), "--case-sensitive-tags", "--rm-tag", "Three")
+	require.Error(t, err)
+
+	_, _, err = ExecuteCmd(createEditOperatorCmd(), "--case-sensitive-tags", "--rm-tag", "three")
+	require.NoError(t, err)
+
+	ac, err := ts.Store.ReadOperatorClaim()
+	require.NoError(t, err)
+	require.Equal(t, ac.Tags, jwt.TagList{"One", "Two"})
+}

--- a/cmd/edituser.go
+++ b/cmd/edituser.go
@@ -71,6 +71,7 @@ nsc edit user --name <n> --rm-response-perms
 			return RunAction(cmd, args, &params)
 		},
 	}
+	cmd.Flags().BoolVarP(&params.caseSensitiveTags, "case-sensitive-tags", "", false, "allow tags values that are not lowercase (false)")
 	cmd.Flags().StringSliceVarP(&params.tags, "tag", "", nil, "add tags for user - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringSliceVarP(&params.rmTags, "rm-tag", "", nil, "remove tag - comma separated list or option can be specified multiple times")
 	cmd.Flags().StringVarP(&params.name, "name", "n", "", "user name")

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.5 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.17.0 // indirect
 	github.com/google/go-github/v30 v30.1.0 // indirect
@@ -52,3 +52,5 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/nats-io/jwt/v2 => /Users/aricart/src/github.com/nats-io/jwt/v2

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,9 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/briandowns/spinner v1.23.1 h1:t5fDPmScwUjozhDj4FA46p5acZWIPXYE30qW2Ptu650=
 github.com/briandowns/spinner v1.23.1/go.mod h1:LaZeM4wm2Ywy6vO571mvhQNRcWfRUnXOs0RcKV0wYKM=
-github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.5 h1:ZtcqGrnekaHpVLArFSe4HK5DoKx1T0rq2DwVB0alcyc=
+github.com/cpuguy83/go-md2man/v2 v2.0.5/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
 github.com/creack/pty v1.1.17/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -69,8 +70,6 @@ github.com/nats-io/cliprompts/v2 v2.0.0-20231014115920-801ca035562a h1:28qvB6peS
 github.com/nats-io/cliprompts/v2 v2.0.0-20231014115920-801ca035562a/go.mod h1:oweZn7AeaVJYKlNHfCIhznJVsdySLSng55vfuINE/d0=
 github.com/nats-io/jsm.go v0.1.2 h1:T4Fq88a03sPAPWYwrOLQ85oanYsC2Bs6517rUiWBMpQ=
 github.com/nats-io/jsm.go v0.1.2/go.mod h1:tnubE70CAKi5TNfQiq6XHFqWTuSIe1H7X4sDwfq6ZK8=
-github.com/nats-io/jwt/v2 v2.6.0 h1:yXoBTdEotZw3NujMT+Nnu1UPNlFWdKQ3d0JJF/+pJag=
-github.com/nats-io/jwt/v2 v2.6.0/go.mod h1:ZdWS1nZa6WMZfFwwgpEaqBV8EPGVgOTDHN/wTbz0Y5A=
 github.com/nats-io/nats-server/v2 v2.10.18 h1:tRdZmBuWKVAFYtayqlBB2BuCHNGAQPvoQIXOKwU3WSM=
 github.com/nats-io/nats-server/v2 v2.10.18/go.mod h1:97Qyg7YydD8blKlR8yBsUlPlWyZKjA7Bp5cl3MUE9K8=
 github.com/nats-io/nats.go v1.37.0 h1:07rauXbVnnJvv1gfIyghFEo6lUcYRY0WXc3x7x0vUxE=


### PR DESCRIPTION
[FEAT] added option `--case-sensitive-tags` to edit operator/account/user if this flag is specified, the tags are passed through as specified. Note that without the option, the values are changed to lowercase and then added or removed.