### PR TITLE
Generate docs on every commit

### DIFF
--- a/.github/workflows/pushes.yaml
+++ b/.github/workflows/pushes.yaml
@@ -125,6 +125,17 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.canonical
 
+      - name: Generate docs
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          go run ./ test doc docs
+
+      - name: Auto-commit generated recordings
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Auto-commit recording
+          file_pattern: docs/**
+          
       - name: Bad versions creep defense
         id: go-module-versions
         # The go.mod includes tests, and some of our tests explicitly pull in jwtv1, which is unmaintained and has security issues.


### PR DESCRIPTION
https://github.com/nats-io/nsc/tree/main/docs
has not been updated for a while:

Can we generate it automatically in every PR, 
similarly to 
https://github.com/ConnectEverything/nats-by-example/blob/e3db9b0e98f2010390ba3dfb02c108ac8accf713/.github/workflows/deploy.yaml#L50C1-L60C71
