### PR TITLE
various fixes regarding enable/disable/validation of Jetstream in the system account

### DIFF
--- a/cmd/editaccount.go
+++ b/cmd/editaccount.go
@@ -598,7 +598,12 @@ func (p *EditAccountParams) checkSystemAccount(ctx ActionCtx) error {
 		return nil
 	}
 
-	if p.claim.Limits.JetStreamTieredLimits != nil {
+	// allow the js to be disabled
+	if p.disableJetStream {
+		return nil
+	}
+
+	if p.claim.Limits.JetStreamTieredLimits != nil || p.enableJetStream > -1 {
 		return errors.New("system account cannot have JetStream limits - please rerun with --js-disable")
 	}
 

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 The NATS Authors
+ * Copyright 2018-2024 The NATS Authors
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -219,6 +219,14 @@ func (p *ValidateCmdParams) validate(ctx ActionCtx) error {
 		aci := p.validateJWT(ac)
 		if aci != nil {
 			p.accountValidations[v] = aci
+		}
+		if oc.SystemAccount == ac.Subject {
+			if ac.Limits.IsJSEnabled() {
+				if p.accountValidations[v] == nil {
+					p.accountValidations[v] = &jwt.ValidationResults{}
+				}
+				p.accountValidations[v].AddError("JetStream should not be enabled for system account")
+			}
 		}
 		if !oc.DidSign(ac) {
 			if p.accountValidations[v] == nil {


### PR DESCRIPTION
- [FIX] added check for --js-enable=tier on system account

- [FIX] added bypass to allow --js-disable to work on system account in cases where it was enabled by specifying --js-enable=tier 

- [FIX] enhanced validation to check for system accounts with enabled jetstream

Fixes #684 