### PR TITLE
Remove unused `jsm.go` dependency and `configureNATSCLI` logic.

### DIFF
--- a/cmd/load.go
+++ b/cmd/load.go
@@ -1,15 +1,17 @@
-// Copyright 2022 The NATS Authors
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+ * Copyright 2022-2025 The NATS Authors
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package cmd
 
@@ -19,13 +21,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nats-io/nsc/v2/cmd/store"
-	"github.com/nats-io/nsc/v2/home"
-
-	"github.com/nats-io/jsm.go/natscontext"
 	"github.com/nats-io/jwt/v2"
 	"github.com/nats-io/nkeys"
-
+	"github.com/nats-io/nsc/v2/cmd/store"
+	"github.com/nats-io/nsc/v2/home"
 	"github.com/spf13/cobra"
 )
 
@@ -355,33 +354,6 @@ func (p *LoadParams) configureNSCEnv() error {
 	return nil
 }
 
-func (p *LoadParams) configureNATSCLI() error {
-	p.contextName = fmt.Sprintf("%s_%s_%s", p.operatorName, p.accountName, p.username)
-
-	// Replace this to use instead use the natscontext library.
-	var servers string
-	if len(p.operator.OperatorServiceURLs) > 0 {
-		servers = strings.Join(p.operator.OperatorServiceURLs, ",")
-	}
-	// Finally, store the NATS context used by the NATS CLI.
-	config, err := natscontext.New(p.contextName, false,
-		natscontext.WithServerURL(servers),
-		natscontext.WithCreds(p.userCreds),
-		natscontext.WithDescription(fmt.Sprintf("%s (%s)", p.operatorName, p.operator.Name)),
-	)
-	if err != nil {
-		return err
-	}
-	config.Save(p.contextName)
-
-	// Switch to use that context as well.
-	err = natscontext.SelectContext(p.contextName)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // Run executes the load profile command.
 func (p *LoadParams) Run(ctx ActionCtx) (store.Status, error) {
 	r := store.NewDetailedReport(false)
@@ -393,9 +365,6 @@ func (p *LoadParams) Run(ctx ActionCtx) (store.Status, error) {
 		return nil, err
 	}
 	if err := p.addUser(ctx); err != nil {
-		return nil, err
-	}
-	if err := p.configureNATSCLI(); err != nil {
 		return nil, err
 	}
 	r.AddOK("created nats context %q", p.contextName)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/nats-io/nsc/v2
 
-go 1.22
-
-toolchain go1.22.5
+go 1.22.0
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
@@ -10,7 +8,6 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nats-io/cliprompts/v2 v2.0.0
-	github.com/nats-io/jsm.go v0.1.2
 	github.com/nats-io/jwt/v2 v2.7.3
 	github.com/nats-io/nats-server/v2 v2.10.24
 	github.com/nats-io/nats.go v1.38.0


### PR DESCRIPTION
This commit cleans up the code by removing the unused `jsm.go` module and the `configureNATSCLI` function, which relied on it. The change reduces unnecessary dependencies and simplifies the `LoadParams` logic, improving maintainability.