### PR TITLE
cmd: add nil check for pull report

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -317,7 +317,7 @@ func (p *PullParams) Run(ctx ActionCtx) (store.Status, error) {
 			sub.AddFromError(j.Err)
 			continue
 		}
-		if j.PullStatus.OK() {
+		if j.PullStatus != nil && j.PullStatus.OK() {
 			token, _ := j.Token()
 			p.maybeStoreJWT(ctx, sub, token)
 		}


### PR DESCRIPTION
In logic of checks inside loop we should add check, because if j.PullStatus == nil and j.err == nil - we do nil dereference