### PR TITLE
chore: update nats-server go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/nats-io/cliprompts/v2 v2.0.0
 	github.com/nats-io/jwt/v2 v2.7.3
-	github.com/nats-io/nats-server/v2 v2.11.0
+	github.com/nats-io/nats-server/v2 v2.11.1
 	github.com/nats-io/nats.go v1.40.1
 	github.com/nats-io/nkeys v0.4.10
 	github.com/nats-io/nuid v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -67,8 +67,8 @@ github.com/nats-io/cliprompts/v2 v2.0.0 h1:VF/H4h1gNbMTlZAQKvXal6XKIEJR9LWLOfCbO
 github.com/nats-io/cliprompts/v2 v2.0.0/go.mod h1:VShjOrI+i3j0OEP9V7IuqfuEI1ysO/TfNfEX2azbNZg=
 github.com/nats-io/jwt/v2 v2.7.3 h1:6bNPK+FXgBeAqdj4cYQ0F8ViHRbi7woQLq4W29nUAzE=
 github.com/nats-io/jwt/v2 v2.7.3/go.mod h1:GvkcbHhKquj3pkioy5put1wvPxs78UlZ7D/pY+BgZk4=
-github.com/nats-io/nats-server/v2 v2.11.0 h1:fdwAT1d6DZW/4LUz5rkvQUe5leGEwjjOQYntzVRKvjE=
-github.com/nats-io/nats-server/v2 v2.11.0/go.mod h1:leXySghbdtXSUmWem8K9McnJ6xbJOb0t9+NQ5HTRZjI=
+github.com/nats-io/nats-server/v2 v2.11.1 h1:LwdauqMqMNhTxTN3+WFTX6wGDOKntHljgZ+7gL5HCnk=
+github.com/nats-io/nats-server/v2 v2.11.1/go.mod h1:leXySghbdtXSUmWem8K9McnJ6xbJOb0t9+NQ5HTRZjI=
 github.com/nats-io/nats.go v1.40.1 h1:MLjDkdsbGUeCMKFyCFoLnNn/HDTqcgVa3EQm+pMNDPk=
 github.com/nats-io/nats.go v1.40.1/go.mod h1:wV73x0FSI/orHPSYoyMeJB+KajMDoWyXmFaRrrYaaTo=
 github.com/nats-io/nkeys v0.4.10 h1:glmRrpCmYLHByYcePvnTBEAwawwapjCPMjy2huw20wc=


### PR DESCRIPTION
NATS Server releases v2.11.1 and v2.10.27 include a fix
for a security vulnerability (CVE):
https://advisories.nats.io/CVE/secnote-2025-01.txt

This PR updates to a patched version that is not vulnerable.

If applicable to this repo, we should also cut a release after merging.

This is a batch change created with https://github.com/lindell/multi-gitter
```
  go get github.com/nats-io/nats-server/v2@patch
  go get toolchain@none
  go mod tidy
```

All PRs in this batch:
https://github.com/search?q=label%3Aabozhenko_multigitter_bump_nats_server_cve_2025_04+state%3Aopen&type=pullrequests