### PR TITLE
feat: tls first for push/pull and tool commands

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -41,6 +41,12 @@ func createPullCmd() *cobra.Command {
 	cmd.Flags().BoolVarP(&params.Overwrite, "overwrite-newer", "F", false, "overwrite local JWTs that are newer than remote")
 	cmd.Flags().StringVarP(&params.sysAcc, "system-account", "", "", "System account for use with nats-resolver enabled nats-server. (Default is system account specified by operator)")
 	cmd.Flags().StringVarP(&params.sysAccUser, "system-user", "", "", "System account user for use with nats-resolver enabled nats-server. (Default to temporarily generated user)")
+
+	cmd.Flags().BoolVarP(&clienttls.tlsFirst, "tls-first", "", false, "use tls-first when connecting to the nats server")
+	cmd.Flags().StringVarP(&clienttls.ca, "ca-cert", "", "", "ca certificate file for tls connections")
+	cmd.Flags().StringVarP(&clienttls.ca, "client-cert", "", "", "client certificate file for tls connections")
+	cmd.Flags().StringVarP(&clienttls.ca, "client-key", "", "", "client key file for tls connections")
+
 	params.AccountContextParams.BindFlags(cmd)
 	return cmd
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -55,6 +55,12 @@ push -P -A (all accounts)`,
 	cmd.Flags().StringVarP(&params.sysAcc, "system-account", "", "", "System account for use with nats-resolver enabled nats-server. (Default is system account specified by operator)")
 	cmd.Flags().StringVarP(&params.sysAccUser, "system-user", "", "", "System account user for use with nats-resolver enabled nats-server. (Default to temporarily generated user)")
 	cmd.Flags().IntVarP(&params.timeout, "timeout", "", 1, "timeout in seconds [1-60] to wait for responses from the server (only applicable to nats-resolver configurations, and applies per operation)")
+
+	cmd.Flags().BoolVarP(&clienttls.tlsFirst, "tls-first", "", false, "use tls-first when connecting to the nats server")
+	cmd.Flags().StringVarP(&clienttls.ca, "ca-cert", "", "", "ca certificate file for tls connections")
+	cmd.Flags().StringVarP(&clienttls.ca, "client-cert", "", "", "client certificate file for tls connections")
+	cmd.Flags().StringVarP(&clienttls.ca, "client-key", "", "", "client key file for tls connections")
+
 	params.AccountContextParams.BindFlags(cmd)
 	return cmd
 }


### PR DESCRIPTION
Add TLS support to push, pull, and tool commands

- Introduced `--tls-first`, `--ca-cert`, `--client-cert`, and `--client-key` flags
- Updated the `push`, `pull`, and `tool` commands to support TLS configuration options.

Fixes #737