### PR TITLE
feat: add pretty UTF8 tables

### DIFF
--- a/cmd/defaults.go
+++ b/cmd/defaults.go
@@ -34,6 +34,7 @@ const NscNoGitIgnoreEnv = "NSC_NO_GIT_IGNORE"
 const NscRootCasNatsEnv = "NATS_CA"
 const NscTlsKeyNatsEnv = "NATS_KEY"
 const NscTlsCertNatsEnv = "NATS_CERT"
+const NscUTF8TableEnv = "NSC_UTF8_TABLE"
 
 type ToolConfig struct {
 	ContextConfig

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"github.com/nats-io/nkeys"
 	"github.com/nats-io/nsc/v2/cmd/store"
 	"github.com/spf13/cobra"
+	"github.com/xlab/tablewriter"
 )
 
 var (
@@ -248,6 +249,9 @@ func SetEnvOptions() {
 }
 
 func init() {
+	if os.Getenv(NscUTF8TableEnv) != "" {
+		tablewriter.EnableUTF8()
+	}
 	SetEnvOptions()
 	root := GetRootCmd()
 	root.Flags().BoolP("version", "v", false, "version for nsc")


### PR DESCRIPTION
Add UTF8 table option by setting `NSC_UTF8_TABLE` environment variable.

I flagged it behind the env var to prevent a breaking change from anyone relying on the existing format of `nsc` or if people prefer the non-UTF8 table. I personally find the current tables busy and hard to read at a glance.

```
=== Without env var ===
+-----------------------------------------------------------------------+
|                               Operators                               |
+------------+----------------------------------------------------------+
| Name       | Public Key                                               |
+------------+----------------------------------------------------------+
| MyOperator | OCBMQXO4TTYWABEEORLPMQS5SDGNXSOLF4NEGN6LU45XDK6L3BXX5TTU |
+------------+----------------------------------------------------------+

=== With env var ===
╭───────────────────────────────────────────────────────────────────────╮
│                               Operators                               │
├────────────┬──────────────────────────────────────────────────────────┤
│ Name       │ Public Key                                               │
├────────────┼──────────────────────────────────────────────────────────┤
│ MyOperator │ OCBMQXO4TTYWABEEORLPMQS5SDGNXSOLF4NEGN6LU45XDK6L3BXX5TTU │
╰────────────┴──────────────────────────────────────────────────────────╯
```