### PR TITLE
test: prevent push tests from leaking cmd/jwt dir

### DIFF
--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -420,7 +420,10 @@ func Test_PushPullSigningKeysRequired(t *testing.T) {
 	data, err := os.ReadFile(serverConf)
 	require.NoError(t, err)
 	dir := ts.AddSubDir(t, "resolver")
-	data = bytes.ReplaceAll(data, []byte(`dir: './jwt'`), []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	oldResolverDir := []byte(`dir: './jwt'`)
+	require.Contains(t, string(data), string(oldResolverDir))
+	data = bytes.ReplaceAll(data, oldResolverDir, []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	require.NotContains(t, string(data), string(oldResolverDir))
 	require.NoError(t, os.WriteFile(serverConf, data, 0660))
 
 	ports := ts.RunServerWithConfig(t, serverConf)

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -417,6 +417,11 @@ func Test_PushPullSigningKeysRequired(t *testing.T) {
 	_, err = ExecuteCmd(createServerConfigCmd(), "--nats-resolver",
 		"--config-file", serverConf)
 	require.NoError(t, err)
+	data, err := os.ReadFile(serverConf)
+	require.NoError(t, err)
+	dir := ts.AddSubDir(t, "resolver")
+	data = bytes.ReplaceAll(data, []byte(`dir: './jwt'`), []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	require.NoError(t, os.WriteFile(serverConf, data, 0660))
 
 	ports := ts.RunServerWithConfig(t, serverConf)
 	defer ts.Server.Shutdown()
@@ -471,6 +476,11 @@ func Test_PushPullScopedOnly(t *testing.T) {
 	_, err = ExecuteCmd(createServerConfigCmd(), "--nats-resolver",
 		"--config-file", serverConf)
 	require.NoError(t, err)
+	data, err := os.ReadFile(serverConf)
+	require.NoError(t, err)
+	dir := ts.AddSubDir(t, "resolver")
+	data = bytes.ReplaceAll(data, []byte(`dir: './jwt'`), []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	require.NoError(t, os.WriteFile(serverConf, data, 0660))
 
 	ports := ts.RunServerWithConfig(t, serverConf)
 	defer ts.Server.Shutdown()
@@ -527,6 +537,11 @@ func Test_PushPullScopedAndNormalOnly(t *testing.T) {
 	_, err = ExecuteCmd(createServerConfigCmd(), "--nats-resolver",
 		"--config-file", serverConf)
 	require.NoError(t, err)
+	data, err := os.ReadFile(serverConf)
+	require.NoError(t, err)
+	dir := ts.AddSubDir(t, "resolver")
+	data = bytes.ReplaceAll(data, []byte(`dir: './jwt'`), []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	require.NoError(t, os.WriteFile(serverConf, data, 0660))
 
 	ports := ts.RunServerWithConfig(t, serverConf)
 	defer ts.Server.Shutdown()
@@ -556,6 +571,11 @@ func Test_PushPullNormalOnly(t *testing.T) {
 	_, err = ExecuteCmd(createServerConfigCmd(), "--nats-resolver",
 		"--config-file", serverConf)
 	require.NoError(t, err)
+	data, err := os.ReadFile(serverConf)
+	require.NoError(t, err)
+	dir := ts.AddSubDir(t, "resolver")
+	data = bytes.ReplaceAll(data, []byte(`dir: './jwt'`), []byte(fmt.Sprintf(`dir: '%s'`, dir)))
+	require.NoError(t, os.WriteFile(serverConf, data, 0660))
 
 	ports := ts.RunServerWithConfig(t, serverConf)
 	defer ts.Server.Shutdown()


### PR DESCRIPTION
## Summary
- Four tests in `cmd/push_test.go` (`Test_PushPullSigningKeysRequired`, `Test_PushPullScopedOnly`, `Test_PushPullScopedAndNormalOnly`, `Test_PushPullNormalOnly`) start an embedded NATS server with `--nats-resolver` but never replace the default `dir: './jwt'` in the generated config.
- During `go test ./cmd/...` the server cwd is `cmd/`, so the resolver creates `cmd/jwt/` and writes pushed account JWTs there, leaving stray files in the repo.
- Apply the same `bytes.ReplaceAll` pattern already used by adjacent tests (e.g. `Test_SyncNewerFromNatsResolver`, `Test_PushPullDeleteWsResolverOption`) to redirect the resolver dir to a per-test temp subdir.

## Test plan
- [x] `rm -rf cmd/jwt && go test ./cmd/ -count=1` — no `cmd/jwt` left behind
- [x] All cmd tests pass